### PR TITLE
feat: Create deployment scripts and configuration for contract

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,8 @@ target/
 **/*.rs.bk
 Cargo.lock
 *.wasm
+.env
+config/deploy.env
 
 # AI & Agent metadata
 .claude/

--- a/DEPLOYMENT.md
+++ b/DEPLOYMENT.md
@@ -1,0 +1,130 @@
+# Deployment Guide
+
+This guide covers building, deploying, initializing, and verifying CommitLabs contracts on
+Stellar Soroban testnet and mainnet.
+
+## Prerequisites
+
+- Rust + Cargo
+- Soroban CLI (`soroban`)
+- Access to a funded deployer account for the target network
+
+## Configuration
+
+Create a local config file:
+
+```bash
+cp config/deploy.env.example config/deploy.env
+```
+
+Set the required values in `config/deploy.env`:
+
+- `STELLAR_ACCOUNT`: secret key, identity name, or public key used to sign transactions
+- `STELLAR_ADMIN_ADDRESS`: public key used as admin in contract initialization
+
+Optional overrides:
+
+- `NETWORK`: `testnet` or `mainnet` (scripts also accept a positional network argument)
+- `STELLAR_RPC_URL`: RPC endpoint
+- `STELLAR_NETWORK_PASSPHRASE`: network passphrase
+- `RUST_TARGET`: default `wasm32v1-none`
+
+## Build
+
+```bash
+bash scripts/build-contracts.sh
+```
+
+## Deploy to Testnet
+
+```bash
+bash scripts/deploy-testnet.sh
+```
+
+## Deploy to Mainnet
+
+```bash
+bash scripts/deploy-mainnet.sh
+```
+
+## Deployment Order
+
+The deployment script enforces the following order:
+
+1. `commitment_nft`
+2. `commitment_core`
+3. `attestation_engine`
+
+## Initialization Steps
+
+The deployment script performs:
+
+- Initialize `commitment_nft` with admin address
+- Initialize `commitment_core` with admin and NFT contract address
+- Set `commitment_core` as the NFT core contract
+- Add `commitment_core` as an authorized minter
+- Initialize `attestation_engine` with admin and core contract address
+
+## Verification Steps
+
+After initialization, the script verifies:
+
+- `commitment_nft.get_admin`
+- `commitment_nft.get_core_contract`
+- `attestation_engine.get_attestations` (with a dummy commitment id)
+
+These checks confirm the contracts respond and the primary addresses are set.
+
+## Contract Address Storage
+
+Deployment outputs are stored in:
+
+- `deployments/testnet.json`
+- `deployments/mainnet.json`
+
+Each file contains network metadata and deployed contract IDs.
+
+## Configuration Options
+
+### Network Defaults
+
+If not explicitly set, the scripts use:
+
+- Testnet RPC: `https://soroban-testnet.stellar.org`
+- Testnet passphrase: `Test SDF Network ; September 2015`
+- Mainnet RPC: `https://soroban-mainnet.stellar.org`
+- Mainnet passphrase: `Public Global Stellar Network ; September 2015`
+
+### Environment Variables
+
+All CLI options can be set via environment variables (per Soroban CLI defaults):
+
+- `STELLAR_ACCOUNT`
+- `STELLAR_RPC_URL`
+- `STELLAR_NETWORK_PASSPHRASE`
+- `STELLAR_FEE`
+
+## Troubleshooting
+
+- **Missing WASM files**: run `bash scripts/build-contracts.sh` and confirm
+  the `target/wasm32v1-none/release/*.wasm` artifacts exist.
+- **Authorization errors**: ensure `STELLAR_ACCOUNT` signs for
+  `STELLAR_ADMIN_ADDRESS` (they should match).
+- **RPC timeouts**: override `STELLAR_RPC_URL` to a reliable RPC provider.
+- **Invoke failures**: re-run with `--very-verbose` to inspect Soroban CLI logs.
+
+## Security Notes
+
+- Do not commit real secrets or funded accounts.
+- Prefer Soroban identities stored in your local key store instead of plain text
+  secret keys in shell history.
+- Rotate keys after test deployments.
+- Restrict admin keys to minimal access and use separate operational keys where possible.
+
+## Rollback Procedures
+
+Smart contracts are immutable once deployed. Rollback should be performed by:
+
+1. Deploying new contract instances.
+2. Updating the stored contract IDs in `deployments/<network>.json`.
+3. Re-initializing dependent services to point at the new addresses.

--- a/README.md
+++ b/README.md
@@ -90,19 +90,17 @@ cargo test --workspace
 The CI will fail fast on any build errors or test failures, ensuring that only valid code is merged into the main branch.
 
 ## Deployment
+Deployment is managed via scripts and documented in `DEPLOYMENT.md`.
 
 ```bash
-# Deploy to testnet
-soroban contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/commitment_nft.wasm \
-  --source <your-key> \
-  --network testnet
+# Build all contracts
+bash scripts/build-contracts.sh
 
-# Deploy to mainnet (when ready)
-soroban contract deploy \
-  --wasm target/wasm32-unknown-unknown/release/commitment_nft.wasm \
-  --source <your-key> \
-  --network mainnet
+# Deploy to testnet
+bash scripts/deploy-testnet.sh
+
+# Deploy to mainnet
+bash scripts/deploy-mainnet.sh
 ```
 
 ## Contract Structure

--- a/config/deploy.env.example
+++ b/config/deploy.env.example
@@ -1,0 +1,13 @@
+## Copy to config/deploy.env and fill in values.
+## Never commit real secrets.
+
+# Deployer account (secret key, identity name, or public key)
+STELLAR_ACCOUNT="SCXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+# Admin address for contract initialization (public key, must be authorized by STELLAR_ACCOUNT)
+STELLAR_ADMIN_ADDRESS="GXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXXX"
+
+# Optional overrides (defaults are selected by network)
+# NETWORK="testnet"
+# STELLAR_RPC_URL="https://soroban-testnet.stellar.org"
+# STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"

--- a/deployments/mainnet.json
+++ b/deployments/mainnet.json
@@ -1,0 +1,4 @@
+{
+  "network": "mainnet",
+  "contracts": {}
+}

--- a/deployments/testnet.json
+++ b/deployments/testnet.json
@@ -1,0 +1,4 @@
+{
+  "network": "testnet",
+  "contracts": {}
+}

--- a/scripts/build-contracts.sh
+++ b/scripts/build-contracts.sh
@@ -1,0 +1,20 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+RUST_TARGET="${RUST_TARGET:-wasm32v1-none}"
+
+echo "Building contracts (target: $RUST_TARGET)..."
+cargo build --workspace --target "$RUST_TARGET" --release
+
+echo "Built artifacts:"
+for contract in commitment_nft commitment_core attestation_engine; do
+  wasm_path="$ROOT_DIR/target/${RUST_TARGET}/release/${contract}.wasm"
+  if [[ ! -f "$wasm_path" ]]; then
+    echo "Missing build artifact: $wasm_path"
+    exit 1
+  fi
+  echo " - $wasm_path"
+done

--- a/scripts/deploy-mainnet.sh
+++ b/scripts/deploy-mainnet.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"$ROOT_DIR/scripts/deploy.sh" mainnet

--- a/scripts/deploy-testnet.sh
+++ b/scripts/deploy-testnet.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+"$ROOT_DIR/scripts/deploy.sh" testnet

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -1,0 +1,156 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "$ROOT_DIR"
+
+if [[ -f "$ROOT_DIR/config/deploy.env" ]]; then
+  # shellcheck disable=SC1091
+  source "$ROOT_DIR/config/deploy.env"
+fi
+
+NETWORK="${1:-${NETWORK:-}}"
+if [[ -z "$NETWORK" ]]; then
+  echo "NETWORK is required (testnet|mainnet)."
+  exit 1
+fi
+
+case "$NETWORK" in
+  testnet|mainnet) ;;
+  *)
+    echo "Unsupported NETWORK: $NETWORK"
+    exit 1
+    ;;
+esac
+
+if [[ -z "${STELLAR_ACCOUNT:-}" ]]; then
+  echo "STELLAR_ACCOUNT is required (secret key, identity, or public key)."
+  exit 1
+fi
+
+if [[ -z "${STELLAR_ADMIN_ADDRESS:-}" ]]; then
+  echo "STELLAR_ADMIN_ADDRESS is required (public key for admin role)."
+  exit 1
+fi
+
+if [[ "$STELLAR_ACCOUNT" == G* && "$STELLAR_ACCOUNT" != "$STELLAR_ADMIN_ADDRESS" ]]; then
+  echo "Warning: STELLAR_ACCOUNT does not match STELLAR_ADMIN_ADDRESS."
+  echo "Authorization may fail if the signer cannot authorize admin actions."
+fi
+
+if [[ -z "${STELLAR_RPC_URL:-}" ]]; then
+  if [[ "$NETWORK" == "testnet" ]]; then
+    STELLAR_RPC_URL="https://soroban-testnet.stellar.org"
+  else
+    STELLAR_RPC_URL="https://soroban-mainnet.stellar.org"
+  fi
+fi
+
+if [[ -z "${STELLAR_NETWORK_PASSPHRASE:-}" ]]; then
+  if [[ "$NETWORK" == "testnet" ]]; then
+    STELLAR_NETWORK_PASSPHRASE="Test SDF Network ; September 2015"
+  else
+    STELLAR_NETWORK_PASSPHRASE="Public Global Stellar Network ; September 2015"
+  fi
+fi
+
+export STELLAR_RPC_URL STELLAR_NETWORK_PASSPHRASE
+
+RUST_TARGET="${RUST_TARGET:-wasm32v1-none}"
+
+echo "Using network: $NETWORK"
+echo "RPC URL: $STELLAR_RPC_URL"
+
+"$ROOT_DIR/scripts/build-contracts.sh"
+
+deploy_contract() {
+  local name="$1"
+  local wasm_path="$2"
+
+  echo "Deploying $name..."
+  local contract_id
+  contract_id=$(soroban contract deploy -q \
+    --wasm "$wasm_path" \
+    --source-account "$STELLAR_ACCOUNT" \
+    --rpc-url "$STELLAR_RPC_URL" \
+    --network-passphrase "$STELLAR_NETWORK_PASSPHRASE")
+
+  if [[ -z "$contract_id" ]]; then
+    echo "Failed to deploy $name."
+    exit 1
+  fi
+
+  echo "$contract_id"
+}
+
+invoke_contract() {
+  local contract_id="$1"
+  shift
+  soroban contract invoke -q \
+    --id "$contract_id" \
+    --source-account "$STELLAR_ACCOUNT" \
+    --rpc-url "$STELLAR_RPC_URL" \
+    --network-passphrase "$STELLAR_NETWORK_PASSPHRASE" \
+    -- "$@"
+}
+
+invoke_view() {
+  local contract_id="$1"
+  shift
+  soroban contract invoke -q \
+    --send no \
+    --id "$contract_id" \
+    --source-account "$STELLAR_ACCOUNT" \
+    --rpc-url "$STELLAR_RPC_URL" \
+    --network-passphrase "$STELLAR_NETWORK_PASSPHRASE" \
+    -- "$@"
+}
+
+NFT_WASM="$ROOT_DIR/target/${RUST_TARGET}/release/commitment_nft.wasm"
+CORE_WASM="$ROOT_DIR/target/${RUST_TARGET}/release/commitment_core.wasm"
+ATTEST_WASM="$ROOT_DIR/target/${RUST_TARGET}/release/attestation_engine.wasm"
+
+NFT_CONTRACT_ID="$(deploy_contract "commitment_nft" "$NFT_WASM")"
+CORE_CONTRACT_ID="$(deploy_contract "commitment_core" "$CORE_WASM")"
+ATTEST_CONTRACT_ID="$(deploy_contract "attestation_engine" "$ATTEST_WASM")"
+
+echo "Initializing contracts..."
+invoke_contract "$NFT_CONTRACT_ID" initialize --admin "$STELLAR_ADMIN_ADDRESS"
+invoke_contract "$CORE_CONTRACT_ID" initialize --_admin "$STELLAR_ADMIN_ADDRESS" --_nft_contract "$NFT_CONTRACT_ID"
+invoke_contract "$NFT_CONTRACT_ID" set_core_contract --core_contract "$CORE_CONTRACT_ID"
+invoke_contract "$NFT_CONTRACT_ID" add_authorized_minter --caller "$STELLAR_ADMIN_ADDRESS" --minter "$CORE_CONTRACT_ID"
+invoke_contract "$ATTEST_CONTRACT_ID" initialize --admin "$STELLAR_ADMIN_ADDRESS" --commitment_core "$CORE_CONTRACT_ID"
+
+echo "Verifying deployments..."
+invoke_view "$NFT_CONTRACT_ID" get_admin
+invoke_view "$NFT_CONTRACT_ID" get_core_contract
+invoke_view "$ATTEST_CONTRACT_ID" get_attestations --commitment_id "deployment_check"
+
+DEPLOYMENTS_DIR="$ROOT_DIR/deployments"
+mkdir -p "$DEPLOYMENTS_DIR"
+
+deployer_account="$STELLAR_ACCOUNT"
+if [[ "$deployer_account" == S* ]]; then
+  deployer_account="secret_key_redacted"
+fi
+
+timestamp="$(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+deployment_file="$DEPLOYMENTS_DIR/${NETWORK}.json"
+
+cat > "$deployment_file" <<EOF
+{
+  "network": "$NETWORK",
+  "rpc_url": "$STELLAR_RPC_URL",
+  "network_passphrase": "$STELLAR_NETWORK_PASSPHRASE",
+  "deployer_account": "$deployer_account",
+  "admin_address": "$STELLAR_ADMIN_ADDRESS",
+  "deployed_at": "$timestamp",
+  "contracts": {
+    "commitment_nft": "$NFT_CONTRACT_ID",
+    "commitment_core": "$CORE_CONTRACT_ID",
+    "attestation_engine": "$ATTEST_CONTRACT_ID"
+  }
+}
+EOF
+
+echo "Deployment complete. Contract addresses saved to $deployment_file"


### PR DESCRIPTION
closes #23 

I have setup the deployment scripts, configuration scaffolding and docs are in place for testnet/mainnet with ordered deploy and  initialization, verification steps, and address storage. I added a single entry-point deploy script with wrappers, a build script, and a full deployment guide covering configuration, troubleshooting, security, and rollback.

Files added/updated:
scripts/build-contracts.sh
scripts/deploy.sh
scripts/deploy-testnet.sh
scripts/deploy-mainnet.sh
config/deploy.env.example
deployments/testnet.json
deployments/mainnet.json
DEPLOYMENT.md
README.md
.gitignore

**How it works:**
* scripts/deploy.sh builds, deploys in order (NFT → Core → Attestation), initializes, verifies, and writes deployments/<network>.json.
* Network defaults (RPC + passphrase) are set by NETWORK unless overridden.
* Admin/signing is configured via config/deploy.env (not committed).

**Next steps:**
* Copy config/deploy.env.example to config/deploy.env and fill in values.
* Run bash scripts/deploy-testnet.sh or bash scripts/deploy-mainnet.sh