### PR TITLE
Add validation and edge case tests for commitment_id and commitment_type 

### DIFF
--- a/contracts/commitment_nft/src/lib.rs
+++ b/contracts/commitment_nft/src/lib.rs
@@ -8,6 +8,9 @@ use soroban_sdk::{
 // Current storage version for migration checks.
 const CURRENT_VERSION: u32 = 1;
 
+// Issue #139: String parameter constraints
+const MAX_COMMITMENT_ID_LENGTH: u32 = 256;
+
 // ============================================================================
 // Error Types
 // ============================================================================
@@ -57,6 +60,8 @@ pub enum ContractError {
     NFTLocked = 19,
     /// Duration would cause expires_at to overflow u64
     ExpirationOverflow = 20,
+    /// Invalid commitment_id (must be non-empty and <= 256 chars)
+    InvalidCommitmentId = 21,
 }
 
 // ============================================================================
@@ -196,6 +201,12 @@ impl CommitmentNFTContract {
         let balanced = String::from_str(e, "balanced");
         let aggressive = String::from_str(e, "aggressive");
         *commitment_type == safe || *commitment_type == balanced || *commitment_type == aggressive
+    }
+
+    /// Validate commitment_id: must be non-empty and not exceed MAX_COMMITMENT_ID_LENGTH
+    fn is_valid_commitment_id(_e: &Env, commitment_id: &String) -> bool {
+        let len = commitment_id.len();
+        len > 0 && len <= MAX_COMMITMENT_ID_LENGTH
     }
 
     /// Set the authorized commitment_core contract address for settlement
@@ -366,6 +377,12 @@ impl CommitmentNFTContract {
                 .instance()
                 .set(&DataKey::ReentrancyGuard, &false);
             return Err(ContractError::InvalidCommitmentType);
+        }
+        if !Self::is_valid_commitment_id(&e, &commitment_id) {
+            e.storage()
+                .instance()
+                .set(&DataKey::ReentrancyGuard, &false);
+            return Err(ContractError::InvalidCommitmentId);
         }
         if initial_amount <= 0 {
             e.storage()


### PR DESCRIPTION
Closes #139 

Changes I made:
- Added MAX_COMMITMENT_ID_LENGTH = 256
- Introduced InvalidCommitmentId error
- Implemented is_valid_commitment_id() validation
- Integrated validation into mint()
- Added 6 edge case tests covering:
  - Empty commitment_id
  - Overlong commitment_id
  - Max-length boundary
  - Valid medium-length ID
  - commitment_type validation
  - Retrieval safety (no panics)

Results:
- 67/67 tests passing (61 existing + 6 new)
- No regressions
- All acceptance criteria satisfied
- Backward compatible (only invalid inputs rejected)

Screenshot:
<img width="831" height="267" alt="image" src="https://github.com/user-attachments/assets/d8ee9ed7-6616-49fa-86ab-dbd4090a7030" />
