### PR TITLE
test: add core fee arithmetic fuzz coverage

### DIFF
--- a/contracts/commitment_core/src/fuzz_tests.rs
+++ b/contracts/commitment_core/src/fuzz_tests.rs
@@ -2,16 +2,14 @@
 
 use crate::{
     fuzzing::{
-        classify_generated_commitment_id_bytes, observe_amount, observe_commitment_input,
-        AmountShape, CommitmentIdShape,
+        checked_fee_value_from_bps, classify_generated_commitment_id_bytes, observe_amount,
+        observe_commitment_input, AmountShape, CommitmentIdShape, FeeValueObservation,
     },
     CommitmentCoreContract, CommitmentCoreContractClient, CommitmentRules,
 };
 use soroban_sdk::{
-    contract, contractimpl,
-    testutils::Address as _,
-    token::StellarAssetClient,
-    Address, Env, String,
+    contract, contractimpl, testutils::Address as _, token::StellarAssetClient, Address, Env,
+    String,
 };
 
 #[contract]
@@ -88,7 +86,6 @@ fn test_fuzz_amount_seed_shapes() {
     assert_eq!(observe_amount(0, 0).shape, AmountShape::NonPositive);
     assert_eq!(observe_amount(-1, 0).shape, AmountShape::NonPositive);
     assert_eq!(observe_amount(1, 10_001).shape, AmountShape::InvalidFeeBps);
-    assert_eq!(observe_amount(i128::MAX, 2).shape, AmountShape::FeeOverflow);
 
     let max_fee = observe_amount(1, 10_000);
     assert_eq!(max_fee.shape, AmountShape::Valid);
@@ -99,6 +96,85 @@ fn test_fuzz_amount_seed_shapes() {
     assert_eq!(normal.shape, AmountShape::Valid);
     assert_eq!(normal.fee, Some(10));
     assert_eq!(normal.net, Some(990));
+
+    let max_adjacent = observe_amount(i128::MAX, 2);
+    assert_eq!(max_adjacent.shape, AmountShape::Valid);
+    assert_eq!(
+        max_adjacent
+            .net
+            .unwrap()
+            .checked_add(max_adjacent.fee.unwrap()),
+        Some(i128::MAX)
+    );
+}
+
+fn assert_fee_value_invariants(amount: i128, bps: u32) {
+    let FeeValueObservation { net, fee } =
+        checked_fee_value_from_bps(amount, bps).expect("valid fee input must compute");
+
+    assert!(
+        fee >= 0,
+        "fee must be non-negative for amount={amount}, bps={bps}"
+    );
+    assert!(
+        fee <= amount,
+        "fee must not exceed amount={amount}, bps={bps}"
+    );
+    assert!(
+        net >= 0,
+        "net must be non-negative for amount={amount}, bps={bps}"
+    );
+    assert_eq!(
+        net.checked_add(fee),
+        Some(amount),
+        "net + fee must conserve amount for amount={amount}, bps={bps}"
+    );
+}
+
+#[test]
+fn test_fuzz_fee_value_seed_boundaries_conserve_amount() {
+    let amounts = [
+        0,
+        1,
+        9_999,
+        10_000,
+        10_001,
+        i128::MAX / 10_000 - 1,
+        i128::MAX / 10_000,
+        i128::MAX / 10_000 + 1,
+        i128::MAX / 2,
+        i128::MAX - 10_000,
+        i128::MAX - 1,
+        i128::MAX,
+    ];
+    let bps_values = [0, 1, 2, 15, 100, 9_999, 10_000];
+
+    for amount in amounts {
+        for bps in bps_values {
+            assert_fee_value_invariants(amount, bps);
+        }
+    }
+}
+
+#[test]
+fn test_fuzz_fee_value_deterministic_input_sweep() {
+    let mut state = 0x9e37_79b9_7f4a_7c15_d1b5_4a32_d192_ed03u128;
+
+    for _ in 0..4096 {
+        state = state
+            .wrapping_mul(0xda94_2042_e4dd_58b5_0000_0000_0000_0001u128)
+            .wrapping_add(0x9e37_79b9_7f4a_7c15u128);
+        let amount = (state >> 1) as i128;
+        let bps = ((state >> 96) % 10_001) as u32;
+
+        assert_fee_value_invariants(amount, bps);
+    }
+}
+
+#[test]
+fn test_fuzz_fee_value_rejects_invalid_domain() {
+    assert_eq!(checked_fee_value_from_bps(-1, 0), None);
+    assert_eq!(checked_fee_value_from_bps(1, 10_001), None);
 }
 
 #[test]
@@ -111,7 +187,7 @@ fn test_fuzz_observation_combines_id_and_amount_seed() {
 }
 
 #[test]
-fn test_create_commitment_rejects_fee_math_overflow() {
+fn test_create_commitment_accepts_max_amount_fee_without_overflow() {
     let e = Env::default();
     e.mock_all_auths_allowing_non_root_auth();
 
@@ -132,10 +208,16 @@ fn test_create_commitment_rejects_fee_math_overflow() {
     client.initialize(&admin, &nft_contract);
     client.set_creation_fee_bps(&admin, &2);
 
-    let result = client.try_create_commitment(&owner, &amount, &asset_address, &default_rules(&e));
+    let commitment_id =
+        client.create_commitment(&owner, &amount, &asset_address, &default_rules(&e));
+    let commitment = client.get_commitment(&commitment_id);
+    let expected_fee = checked_fee_value_from_bps(amount, 2).unwrap().fee;
+    let expected_net = amount.checked_sub(expected_fee).unwrap();
 
-    assert!(result.is_err());
-    assert_eq!(client.get_total_commitments(), 0);
-    assert_eq!(client.get_total_value_locked(), 0);
-    assert_eq!(client.get_collected_fees(&asset_address), 0);
+    assert_eq!(commitment.amount, expected_net);
+    assert_eq!(commitment.current_value, expected_net);
+    assert_eq!(client.get_total_commitments(), 1);
+    assert_eq!(client.get_total_value_locked(), expected_net);
+    assert_eq!(client.get_collected_fees(&asset_address), expected_fee);
+    assert_eq!(expected_net.checked_add(expected_fee), Some(amount));
 }

--- a/contracts/commitment_core/src/fuzzing.rs
+++ b/contracts/commitment_core/src/fuzzing.rs
@@ -42,6 +42,12 @@ pub struct CommitmentInputObservation {
     pub amount: AmountObservation,
 }
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct FeeValueObservation {
+    pub net: i128,
+    pub fee: i128,
+}
+
 pub fn classify_generated_commitment_id_bytes(bytes: &[u8]) -> CommitmentIdShape {
     if bytes.is_empty() {
         return CommitmentIdShape::Empty;
@@ -68,13 +74,30 @@ pub fn classify_generated_commitment_id_bytes(bytes: &[u8]) -> CommitmentIdShape
 }
 
 pub fn checked_fee_from_bps(amount: i128, fee_bps: u32) -> Option<i128> {
+    if amount < 0 {
+        return None;
+    }
+
     if fee_bps > BPS_MAX {
         return None;
     }
 
-    amount
-        .checked_mul(fee_bps as i128)?
-        .checked_div(BPS_SCALE as i128)
+    let scale = BPS_SCALE as i128;
+    let fee_bps = fee_bps as i128;
+    let whole_units = amount / scale;
+    let remainder = amount % scale;
+
+    let whole_fee = whole_units.checked_mul(fee_bps)?;
+    let remainder_fee = remainder.checked_mul(fee_bps)?.checked_div(scale)?;
+
+    whole_fee.checked_add(remainder_fee)
+}
+
+pub fn checked_fee_value_from_bps(amount: i128, fee_bps: u32) -> Option<FeeValueObservation> {
+    let fee = checked_fee_from_bps(amount, fee_bps)?;
+    let net = amount.checked_sub(fee)?;
+
+    Some(FeeValueObservation { net, fee })
 }
 
 pub fn observe_amount(amount: i128, fee_bps: u32) -> AmountObservation {
@@ -94,18 +117,10 @@ pub fn observe_amount(amount: i128, fee_bps: u32) -> AmountObservation {
         };
     }
 
-    let Some(fee) = checked_fee_from_bps(amount, fee_bps) else {
+    let Some(FeeValueObservation { net, fee }) = checked_fee_value_from_bps(amount, fee_bps) else {
         return AmountObservation {
             shape: AmountShape::FeeOverflow,
             fee: None,
-            net: None,
-        };
-    };
-
-    let Some(net) = amount.checked_sub(fee) else {
-        return AmountObservation {
-            shape: AmountShape::NetUnderflow,
-            fee: Some(fee),
             net: None,
         };
     };
@@ -117,7 +132,11 @@ pub fn observe_amount(amount: i128, fee_bps: u32) -> AmountObservation {
     }
 }
 
-pub fn observe_commitment_input(commitment_id: &[u8], amount: i128, fee_bps: u32) -> CommitmentInputObservation {
+pub fn observe_commitment_input(
+    commitment_id: &[u8],
+    amount: i128,
+    fee_bps: u32,
+) -> CommitmentInputObservation {
     CommitmentInputObservation {
         id_shape: classify_generated_commitment_id_bytes(commitment_id),
         amount: observe_amount(amount, fee_bps),

--- a/contracts/shared_utils/src/fees.rs
+++ b/contracts/shared_utils/src/fees.rs
@@ -31,11 +31,21 @@ pub fn fee_from_bps(amount: i128, bps: u32) -> i128 {
     if bps == 0 {
         return 0;
     }
-    amount
-        .checked_mul(bps as i128)
+    let scale = BPS_SCALE as i128;
+    let bps = bps as i128;
+    let whole_units = amount / scale;
+    let remainder = amount % scale;
+
+    let whole_fee = whole_units.checked_mul(bps).expect("Fees: overflow");
+    let remainder_fee = remainder
+        .checked_mul(bps)
         .expect("Fees: overflow")
-        .checked_div(BPS_SCALE as i128)
-        .expect("Fees: div by zero")
+        .checked_div(scale)
+        .expect("Fees: div by zero");
+
+    whole_fee
+        .checked_add(remainder_fee)
+        .expect("Fees: overflow")
 }
 
 /// Net amount after deducting a fee in basis points.
@@ -69,6 +79,20 @@ mod tests {
     #[test]
     fn test_fee_from_bps_hundred_percent() {
         assert_eq!(fee_from_bps(1000, 10000), 1000);
+    }
+
+    #[test]
+    fn test_fee_from_bps_max_amount_boundaries() {
+        assert_eq!(fee_from_bps(i128::MAX, 0), 0);
+        assert_eq!(fee_from_bps(i128::MAX, 10_000), i128::MAX);
+
+        let fee = fee_from_bps(i128::MAX, 2);
+        assert!(fee >= 0);
+        assert!(fee <= i128::MAX);
+        assert_eq!(
+            i128::MAX.checked_sub(fee).unwrap().checked_add(fee),
+            Some(i128::MAX)
+        );
     }
 
     #[test]

--- a/contracts/shared_utils/src/fees.rs
+++ b/contracts/shared_utils/src/fees.rs
@@ -97,7 +97,7 @@ mod tests {
 
     #[test]
     fn test_fee_from_bps_rounds_down() {
-        assert_eq!(fee_from_bps(100, 15), 0); // 1.5% of 100 = 1.5 -> 1
+        assert_eq!(fee_from_bps(100, 15), 0); // 0.15% of 100 = 0.15 -> 0
         assert_eq!(fee_from_bps(1000, 33), 3); // 3.3% rounds down
     }
 

--- a/docs/SECURITY_AUDIT_PREP.md
+++ b/docs/SECURITY_AUDIT_PREP.md
@@ -30,6 +30,12 @@
 - Cross-contract calls (token transfer, NFT mint/settle, commitment_core reads)
 - Storage growth and data consistency for vectors and registries
 
+## Deterministic fuzz properties
+- `commitment_core` fee arithmetic is covered by deterministic fuzz-style seed tests in `contracts/commitment_core/src/fuzz_tests.rs`.
+- For every covered `amount >= 0` and `bps in 0..=10000`, `checked_fee_value_from_bps` must produce `fee >= 0`, `fee <= amount`, `net >= 0`, and `net + fee == amount`.
+- Boundary seeds include `amount = 0`, `bps = 0`, `bps = 10000`, `i128::MAX / 10000` neighbors, `i128::MAX - 1`, and `i128::MAX`.
+- The `create_commitment` fee path is checked with an `i128::MAX` amount so the shared `fee_from_bps` implementation cannot regress to multiply-before-divide overflow.
+
 ## Open items before audit
 - Capture a coverage report and attach to TEST_COVERAGE.md
 - Decide on authorization model for mint/allocate/settle flows


### PR DESCRIPTION
## Summary
- make basis-point fee calculation avoid multiply-before-divide overflow on valid max-amount inputs
- add deterministic fuzz-style coverage for fee bounds and net-plus-fee conservation across boundary and generated inputs
- document the fee/value arithmetic properties in the security audit prep guide

Closes #486

## Validation
- git diff --check
- rustfmt --check contracts/commitment_core/src/fuzzing.rs contracts/commitment_core/src/fuzz_tests.rs contracts/shared_utils/src/fees.rs
- verified the fuzz/property tests cover amount boundaries, bps boundaries, invalid domains, and the create_commitment fee path