### PR TITLE
test: cover nft transfer authorization

### DIFF
--- a/contracts/commitment_nft/src/lib.rs
+++ b/contracts/commitment_nft/src/lib.rs
@@ -210,6 +210,9 @@ mod tests;
 #[cfg(test)]
 mod smoke_tests;
 
+#[cfg(test)]
+mod transfer_authorization_tests;
+
 // ============================================================================
 // Contract Implementation
 // ============================================================================

--- a/contracts/commitment_nft/src/tests.rs
+++ b/contracts/commitment_nft/src/tests.rs
@@ -122,6 +122,28 @@ fn assert_balance_supply_invariant(client: &CommitmentNFTContractClient, owners:
     );
 }
 
+fn assert_owner_inventory(
+    client: &CommitmentNFTContractClient,
+    owner: &SdkAddress,
+    expected_token_ids: &[u32],
+) {
+    assert_eq!(client.balance_of(owner), expected_token_ids.len() as u32);
+
+    let owner_nfts = client.get_nfts_by_owner(owner);
+    assert_eq!(owner_nfts.len(), expected_token_ids.len() as u32);
+
+    for token_id in expected_token_ids {
+        assert_eq!(client.owner_of(token_id), owner.clone());
+        assert!(
+            owner_nfts
+                .iter()
+                .any(|nft| nft.token_id == *token_id && nft.owner == owner.clone()),
+            "owner inventory missing token_id {}",
+            token_id
+        );
+    }
+}
+
 /// Convenience wrapper that mints a 1-day duration NFT with default params.
 /// Returns the token_id.
 fn mint_to_owner(
@@ -3135,6 +3157,96 @@ fn test_consistency_after_transfers() {
     // Sum of all individual balances should equal total supply
     let total_individual_balances = client.balance_of(&owner1) + client.balance_of(&owner2);
     assert_eq!(total_individual_balances, client.total_supply());
+}
+
+#[test]
+fn test_transfer_authorization_failures_preserve_active_owner_state() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (admin, client) = setup_contract(&e);
+    let owner = Address::generate(&e);
+    let not_owner = Address::generate(&e);
+    let recipient = Address::generate(&e);
+    let asset_address = Address::generate(&e);
+
+    client.initialize(&admin);
+    let token_id = client.mint(
+        &admin,
+        &owner,
+        &String::from_str(&e, "transfer_auth_active"),
+        &1,
+        &10,
+        &String::from_str(&e, "safe"),
+        &1000,
+        &asset_address,
+        &5,
+    );
+
+    assert_eq!(client.is_active(&token_id), true);
+    assert_owner_inventory(&client, &owner, &[token_id]);
+    assert_owner_inventory(&client, &recipient, &[]);
+
+    let not_owner_result = client.try_transfer(&not_owner, &recipient, &token_id);
+    assert!(not_owner_result.is_err());
+
+    let active_owner_result = client.try_transfer(&owner, &recipient, &token_id);
+    assert!(active_owner_result.is_err());
+
+    assert_eq!(client.is_active(&token_id), true);
+    assert_owner_inventory(&client, &owner, &[token_id]);
+    assert_owner_inventory(&client, &recipient, &[]);
+    assert_balance_supply_invariant(&client, &[&owner, &recipient]);
+}
+
+#[test]
+fn test_inactive_transfer_requires_current_owner_and_updates_owner_indexes() {
+    let e = Env::default();
+    e.mock_all_auths();
+
+    let (admin, client, _core_id) = setup_contract_with_core(&e);
+    let owner = Address::generate(&e);
+    let recipient = Address::generate(&e);
+    let authorized_minter = Address::generate(&e);
+    let final_recipient = Address::generate(&e);
+    let asset_address = Address::generate(&e);
+
+    client.add_authorized_contract(&admin, &authorized_minter).unwrap();
+    assert!(client.is_authorized(&authorized_minter));
+
+    let token_id = client.mint(
+        &admin,
+        &owner,
+        &String::from_str(&e, "transfer_auth_inactive"),
+        &1,
+        &10,
+        &String::from_str(&e, "safe"),
+        &1000,
+        &asset_address,
+        &5,
+    );
+
+    e.ledger().with_mut(|li| {
+        li.timestamp = 172800;
+    });
+    settle_as_core(&client, &token_id);
+    assert_eq!(client.is_active(&token_id), false);
+
+    let authorized_minter_result =
+        client.try_transfer(&authorized_minter, &recipient, &token_id);
+    assert!(authorized_minter_result.is_err());
+    assert_owner_inventory(&client, &owner, &[token_id]);
+    assert_owner_inventory(&client, &recipient, &[]);
+
+    client.transfer(&owner, &recipient, &token_id);
+    assert_owner_inventory(&client, &owner, &[]);
+    assert_owner_inventory(&client, &recipient, &[token_id]);
+
+    let old_owner_result = client.try_transfer(&owner, &final_recipient, &token_id);
+    assert!(old_owner_result.is_err());
+    assert_owner_inventory(&client, &recipient, &[token_id]);
+    assert_owner_inventory(&client, &final_recipient, &[]);
+    assert_balance_supply_invariant(&client, &[&owner, &recipient, &final_recipient]);
 }
 
 /// Test consistency with empty collections

--- a/contracts/commitment_nft/src/tests.rs
+++ b/contracts/commitment_nft/src/tests.rs
@@ -122,28 +122,6 @@ fn assert_balance_supply_invariant(client: &CommitmentNFTContractClient, owners:
     );
 }
 
-fn assert_owner_inventory(
-    client: &CommitmentNFTContractClient,
-    owner: &SdkAddress,
-    expected_token_ids: &[u32],
-) {
-    assert_eq!(client.balance_of(owner), expected_token_ids.len() as u32);
-
-    let owner_nfts = client.get_nfts_by_owner(owner);
-    assert_eq!(owner_nfts.len(), expected_token_ids.len() as u32);
-
-    for token_id in expected_token_ids {
-        assert_eq!(client.owner_of(token_id), owner.clone());
-        assert!(
-            owner_nfts
-                .iter()
-                .any(|nft| nft.token_id == *token_id && nft.owner == owner.clone()),
-            "owner inventory missing token_id {}",
-            token_id
-        );
-    }
-}
-
 /// Convenience wrapper that mints a 1-day duration NFT with default params.
 /// Returns the token_id.
 fn mint_to_owner(
@@ -3157,96 +3135,6 @@ fn test_consistency_after_transfers() {
     // Sum of all individual balances should equal total supply
     let total_individual_balances = client.balance_of(&owner1) + client.balance_of(&owner2);
     assert_eq!(total_individual_balances, client.total_supply());
-}
-
-#[test]
-fn test_transfer_authorization_failures_preserve_active_owner_state() {
-    let e = Env::default();
-    e.mock_all_auths();
-
-    let (admin, client) = setup_contract(&e);
-    let owner = Address::generate(&e);
-    let not_owner = Address::generate(&e);
-    let recipient = Address::generate(&e);
-    let asset_address = Address::generate(&e);
-
-    client.initialize(&admin);
-    let token_id = client.mint(
-        &admin,
-        &owner,
-        &String::from_str(&e, "transfer_auth_active"),
-        &1,
-        &10,
-        &String::from_str(&e, "safe"),
-        &1000,
-        &asset_address,
-        &5,
-    );
-
-    assert_eq!(client.is_active(&token_id), true);
-    assert_owner_inventory(&client, &owner, &[token_id]);
-    assert_owner_inventory(&client, &recipient, &[]);
-
-    let not_owner_result = client.try_transfer(&not_owner, &recipient, &token_id);
-    assert!(not_owner_result.is_err());
-
-    let active_owner_result = client.try_transfer(&owner, &recipient, &token_id);
-    assert!(active_owner_result.is_err());
-
-    assert_eq!(client.is_active(&token_id), true);
-    assert_owner_inventory(&client, &owner, &[token_id]);
-    assert_owner_inventory(&client, &recipient, &[]);
-    assert_balance_supply_invariant(&client, &[&owner, &recipient]);
-}
-
-#[test]
-fn test_inactive_transfer_requires_current_owner_and_updates_owner_indexes() {
-    let e = Env::default();
-    e.mock_all_auths();
-
-    let (admin, client, _core_id) = setup_contract_with_core(&e);
-    let owner = Address::generate(&e);
-    let recipient = Address::generate(&e);
-    let authorized_minter = Address::generate(&e);
-    let final_recipient = Address::generate(&e);
-    let asset_address = Address::generate(&e);
-
-    client.add_authorized_contract(&admin, &authorized_minter).unwrap();
-    assert!(client.is_authorized(&authorized_minter));
-
-    let token_id = client.mint(
-        &admin,
-        &owner,
-        &String::from_str(&e, "transfer_auth_inactive"),
-        &1,
-        &10,
-        &String::from_str(&e, "safe"),
-        &1000,
-        &asset_address,
-        &5,
-    );
-
-    e.ledger().with_mut(|li| {
-        li.timestamp = 172800;
-    });
-    settle_as_core(&client, &token_id);
-    assert_eq!(client.is_active(&token_id), false);
-
-    let authorized_minter_result =
-        client.try_transfer(&authorized_minter, &recipient, &token_id);
-    assert!(authorized_minter_result.is_err());
-    assert_owner_inventory(&client, &owner, &[token_id]);
-    assert_owner_inventory(&client, &recipient, &[]);
-
-    client.transfer(&owner, &recipient, &token_id);
-    assert_owner_inventory(&client, &owner, &[]);
-    assert_owner_inventory(&client, &recipient, &[token_id]);
-
-    let old_owner_result = client.try_transfer(&owner, &final_recipient, &token_id);
-    assert!(old_owner_result.is_err());
-    assert_owner_inventory(&client, &recipient, &[token_id]);
-    assert_owner_inventory(&client, &final_recipient, &[]);
-    assert_balance_supply_invariant(&client, &[&owner, &recipient, &final_recipient]);
 }
 
 /// Test consistency with empty collections

--- a/contracts/commitment_nft/src/transfer_authorization_tests.rs
+++ b/contracts/commitment_nft/src/transfer_authorization_tests.rs
@@ -1,0 +1,133 @@
+#![cfg(test)]
+
+use super::*;
+use soroban_sdk::{
+    testutils::{Address as _, Ledger},
+    Address, Env, String,
+};
+
+fn setup_contract(e: &Env) -> (Address, CommitmentNFTContractClient<'_>) {
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, CommitmentNFTContract);
+    let client = CommitmentNFTContractClient::new(e, &contract_id);
+    let admin = Address::generate(e);
+    client.initialize(&admin);
+    (admin, client)
+}
+
+fn setup_contract_with_core(e: &Env) -> (Address, CommitmentNFTContractClient<'_>, Address) {
+    let (admin, client) = setup_contract(e);
+    let core_contract = Address::generate(e);
+    client.set_core_contract(&core_contract);
+    (admin, client, core_contract)
+}
+
+fn mint_test_nft(
+    e: &Env,
+    client: &CommitmentNFTContractClient,
+    caller: &Address,
+    owner: &Address,
+    label: &str,
+) -> u32 {
+    let asset_address = Address::generate(e);
+    client.mint(
+        caller,
+        owner,
+        &String::from_str(e, label),
+        &1,
+        &10,
+        &String::from_str(e, "safe"),
+        &1_000,
+        &asset_address,
+        &5,
+    )
+}
+
+fn assert_owner_inventory(
+    client: &CommitmentNFTContractClient,
+    owner: &Address,
+    expected_token_ids: &[u32],
+) {
+    assert_eq!(client.balance_of(owner), expected_token_ids.len() as u32);
+
+    let owner_nfts = client.get_nfts_by_owner(owner);
+    assert_eq!(owner_nfts.len(), expected_token_ids.len() as u32);
+
+    for token_id in expected_token_ids {
+        assert_eq!(client.owner_of(token_id), owner.clone());
+        assert!(
+            owner_nfts
+                .iter()
+                .any(|nft| nft.token_id == *token_id && nft.owner == owner.clone()),
+            "owner inventory missing token_id {}",
+            token_id,
+        );
+    }
+}
+
+fn assert_balance_supply_invariant(client: &CommitmentNFTContractClient, owners: &[&Address]) {
+    let balance_sum: u32 = owners.iter().map(|owner| client.balance_of(owner)).sum();
+    assert_eq!(balance_sum, client.total_supply());
+}
+
+#[test]
+fn transfer_rejects_non_owner_and_active_owner_without_mutating_inventory() {
+    let e = Env::default();
+    let (admin, client) = setup_contract(&e);
+    let owner = Address::generate(&e);
+    let not_owner = Address::generate(&e);
+    let recipient = Address::generate(&e);
+    let token_id = mint_test_nft(&e, &client, &admin, &owner, "transfer_auth_active");
+
+    assert!(client.is_active(&token_id));
+    assert_owner_inventory(&client, &owner, &[token_id]);
+    assert_owner_inventory(&client, &recipient, &[]);
+
+    let not_owner_result = client.try_transfer(&not_owner, &recipient, &token_id);
+    assert!(not_owner_result.is_err());
+
+    let active_owner_result = client.try_transfer(&owner, &recipient, &token_id);
+    assert!(active_owner_result.is_err());
+
+    assert!(client.is_active(&token_id));
+    assert_owner_inventory(&client, &owner, &[token_id]);
+    assert_owner_inventory(&client, &recipient, &[]);
+    assert_balance_supply_invariant(&client, &[&owner, &recipient]);
+}
+
+#[test]
+fn inactive_transfer_requires_current_owner_and_updates_owner_indexes() {
+    let e = Env::default();
+    let (admin, client, core_contract) = setup_contract_with_core(&e);
+    let owner = Address::generate(&e);
+    let recipient = Address::generate(&e);
+    let authorized_minter = Address::generate(&e);
+    let final_recipient = Address::generate(&e);
+
+    client
+        .add_authorized_contract(&admin, &authorized_minter)
+        .unwrap();
+    assert!(client.is_authorized(&authorized_minter));
+
+    let token_id = mint_test_nft(&e, &client, &admin, &owner, "transfer_auth_inactive");
+    e.ledger().with_mut(|ledger| {
+        ledger.timestamp = 172_800;
+    });
+    client.settle(&core_contract, &token_id);
+    assert!(!client.is_active(&token_id));
+
+    let authorized_minter_result = client.try_transfer(&authorized_minter, &recipient, &token_id);
+    assert!(authorized_minter_result.is_err());
+    assert_owner_inventory(&client, &owner, &[token_id]);
+    assert_owner_inventory(&client, &recipient, &[]);
+
+    client.transfer(&owner, &recipient, &token_id);
+    assert_owner_inventory(&client, &owner, &[]);
+    assert_owner_inventory(&client, &recipient, &[token_id]);
+
+    let old_owner_result = client.try_transfer(&owner, &final_recipient, &token_id);
+    assert!(old_owner_result.is_err());
+    assert_owner_inventory(&client, &recipient, &[token_id]);
+    assert_owner_inventory(&client, &final_recipient, &[]);
+    assert_balance_supply_invariant(&client, &[&owner, &recipient, &final_recipient]);
+}

--- a/docs/commitment_nft/SETTLEMENT_AUTHORIZATION.md
+++ b/docs/commitment_nft/SETTLEMENT_AUTHORIZATION.md
@@ -39,6 +39,21 @@ For direct generated-client usage, callers must now provide the trusted core con
 
 No owner balances, owner token registries, token counters, or total supply values are mutated during settlement.
 
+## Transfer Authorization Coverage
+
+`commitment_nft::transfer` remains owner-driven even when another address is admin,
+core, or an authorized minter:
+
+- Active NFTs are locked and cannot transfer until `settle` or `mark_inactive`
+  flips `is_active` to `false`.
+- Authorized minter status does not grant transfer authority; the `from` address
+  must still be the current owner.
+- Successful inactive-token transfers must update `owner_of`, `balance_of`, and
+  `get_nfts_by_owner` consistently without changing `total_supply`.
+
+The regression tests in `contracts/commitment_nft/src/tests.rs` cover both failed
+authorization attempts and successful inactive-token ownership-index updates.
+
 ## Migration Notes
 
 - On-chain storage layout does not change.


### PR DESCRIPTION
## Summary
- add focused commitment_nft transfer authorization tests for active locked NFTs, non-owner attempts, and authorized-minter non-bypass behavior
- assert owner_of, balance_of, get_nfts_by_owner, and total_supply stay consistent across failed and successful inactive-token transfers
- document transfer authorization coverage in the settlement authorization guide

Closes #485

## Validation
- git diff --check
- verified added tests cover active transfer rejection, non-owner rejection, authorized-minter non-bypass, inactive owner transfer, owner-index updates, and supply conservation