### PR TITLE
test: cover price oracle staleness boundaries

### DIFF
--- a/contracts/price_oracle/src/tests.rs
+++ b/contracts/price_oracle/src/tests.rs
@@ -66,7 +66,7 @@ fn test_admin_transfer_and_oracle_control() {
 
 use super::*;
 use soroban_sdk::testutils::{Address as _, Ledger};
-use soroban_sdk::{Bytes, BytesN};
+use soroban_sdk::{Bytes, BytesN, Vec};
 
 fn upload_wasm(e: &Env) -> BytesN<32> {
     // Empty WASM is accepted in testutils and is sufficient for upgrade tests.
@@ -318,6 +318,103 @@ fn test_get_price_valid_accepts_exact_staleness_boundary() {
     let data = client.get_price_valid(&asset, &None);
     assert_eq!(data.price, 42_00000000);
     assert_eq!(data.decimals, 8);
+}
+
+#[test]
+fn test_get_price_valid_rejects_one_second_past_staleness_boundary() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let oracle = Address::generate(&e);
+    let asset = Address::generate(&e);
+    let contract_id = e.register_contract(None, PriceOracleContract);
+    let client = PriceOracleContractClient::new(&e, &contract_id);
+
+    e.as_contract(&contract_id, || {
+        PriceOracleContract::initialize(e.clone(), admin.clone()).unwrap();
+        PriceOracleContract::add_oracle(e.clone(), admin.clone(), oracle.clone()).unwrap();
+    });
+
+    client.set_price(&oracle, &asset, &42_00000000, &8);
+    e.ledger().with_mut(|li| {
+        li.timestamp += 3601;
+    });
+
+    assert_eq!(
+        client.try_get_price_valid(&asset, &None),
+        Err(Ok(OracleError::StalePrice))
+    );
+}
+
+#[test]
+fn test_get_price_valid_uses_legacy_max_staleness_fallback_boundary() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let oracle = Address::generate(&e);
+    let asset = Address::generate(&e);
+    let contract_id = e.register_contract(None, PriceOracleContract);
+    let client = PriceOracleContractClient::new(&e, &contract_id);
+
+    e.as_contract(&contract_id, || {
+        PriceOracleContract::initialize(e.clone(), admin.clone()).unwrap();
+        PriceOracleContract::add_oracle(e.clone(), admin.clone(), oracle.clone()).unwrap();
+        e.storage().instance().remove(&DataKey::OracleConfig);
+        e.storage()
+            .instance()
+            .set(&DataKey::MaxStalenessSeconds, &120u64);
+    });
+
+    assert_eq!(client.get_max_staleness(), 120);
+
+    client.set_price(&oracle, &asset, &77_00000000, &8);
+    e.ledger().with_mut(|li| {
+        li.timestamp += 120;
+    });
+
+    let boundary_data = client.get_price_valid(&asset, &None);
+    assert_eq!(boundary_data.price, 77_00000000);
+
+    e.ledger().with_mut(|li| {
+        li.timestamp += 1;
+    });
+
+    assert_eq!(
+        client.try_get_price_valid(&asset, &None),
+        Err(Ok(OracleError::StalePrice))
+    );
+}
+
+#[test]
+fn test_get_batch_prices_rejects_mixed_fresh_and_stale_assets() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let admin = Address::generate(&e);
+    let oracle = Address::generate(&e);
+    let stale_asset = Address::generate(&e);
+    let fresh_asset = Address::generate(&e);
+    let contract_id = e.register_contract(None, PriceOracleContract);
+    let client = PriceOracleContractClient::new(&e, &contract_id);
+
+    e.as_contract(&contract_id, || {
+        PriceOracleContract::initialize(e.clone(), admin.clone()).unwrap();
+        PriceOracleContract::add_oracle(e.clone(), admin.clone(), oracle.clone()).unwrap();
+    });
+
+    client.set_price(&oracle, &stale_asset, &10_00000000, &8);
+    e.ledger().with_mut(|li| {
+        li.timestamp += 61;
+    });
+    client.set_price(&oracle, &fresh_asset, &20_00000000, &8);
+
+    let mut assets = Vec::new(&e);
+    assets.push_back(fresh_asset);
+    assets.push_back(stale_asset);
+
+    assert_eq!(
+        client.try_get_batch_prices(&assets, &60),
+        Err(Ok(OracleError::StalePrice))
+    );
 }
 
 #[test]

--- a/docs/THREAT_MODEL.md
+++ b/docs/THREAT_MODEL.md
@@ -75,6 +75,9 @@
 - **Mitigations:** Admin-managed oracle whitelist, `require_auth` on oracle/admin paths, non-negative price validation, and `get_price_valid` freshness checks that reject stale and future-dated prices.
 - **Assumptions:** `price_oracle` is a trusted-publisher registry, not an on-chain aggregation engine. It does not implement TWAP, medianization, quorum, circuit breakers, or cross-source reconciliation.
 - **Integrator responsibility:** Consumers must call `get_price_valid` with an appropriate staleness bound for the asset and use case; `get_price` is a raw read helper and does not enforce freshness.
+- **Freshness boundary matrix:** `get_price_valid` treats `current_time - updated_at < max_staleness_seconds` as fresh, accepts the exact boundary (`age == max_staleness_seconds`), rejects one second past the boundary (`age == max_staleness_seconds + 1`) with `StalePrice`, and rejects future-dated prices where `updated_at > current_time` with `StalePrice`.
+- **Legacy config compatibility:** When the structured `OracleConfig` key is absent, `read_config` falls back to the legacy `MaxStalenessSeconds` key and applies the same freshness-boundary matrix. Migration tests should continue to verify this fallback until all deployed legacy instances have been upgraded.
+- **Batch behavior:** `get_batch_prices` fails closed: a single stale asset in a batch returns `StalePrice` for the full batch rather than returning partial results.
 - **Audit focus:** Whether single-source trust is acceptable for each asset, whether admin key management around whitelist updates is strong enough, and whether downstream contracts choose staleness windows that match liquidation/settlement risk.
 
 ## Residual risks


### PR DESCRIPTION
## Summary
- add host-side tests for `price_oracle::get_price_valid` staleness boundaries
- cover one second past the default boundary, legacy `MaxStalenessSeconds` fallback behavior, and batch fail-closed behavior with one stale asset
- document the freshness boundary matrix, legacy fallback, and batch semantics in the threat model

Closes #481

## Tests
- `cargo test -p price_oracle` (39 passed)

## Notes
- `cargo test -p price_oracle` emits a pre-existing warning for unused `max_deviation_percent` in `contracts/price_oracle/src/lib.rs`.
- Workspace `cargo fmt` is blocked by unrelated pre-existing syntax/mismatched delimiter errors in `contracts/commitment_nft/src/tests.rs`, so this PR keeps the diff scoped to the intended price oracle tests and threat-model docs.
