### PR TITLE
Add migration idempotency tests

### DIFF
--- a/contracts/allocation_logic/src/tests.rs
+++ b/contracts/allocation_logic/src/tests.rs
@@ -2,8 +2,8 @@
 extern crate std;
 
 use crate::{
-    AllocationStrategiesContract, AllocationStrategiesContractClient, RiskLevel, Strategy,
-    Commitment, CommitmentRules,
+    AllocationStrategiesContract, AllocationStrategiesContractClient, Error, RiskLevel, Strategy,
+    Commitment, CommitmentRules, CURRENT_VERSION,
 };
 use soroban_sdk::{
     contract, contractimpl, testutils::Address as _, testutils::Ledger, Address, Env, Map, String,
@@ -88,6 +88,63 @@ fn setup_test_pools(_env: &Env, client: &AllocationStrategiesContractClient, adm
     client.register_pool(admin, &3, &RiskLevel::Medium, &1200, &800_000_000);
     client.register_pool(admin, &4, &RiskLevel::High, &2000, &500_000_000);
     client.register_pool(admin, &5, &RiskLevel::High, &2500, &500_000_000);
+}
+
+#[test]
+fn test_migrate_rejects_wrong_from_version_without_mutating_state() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, _core_id, client) = create_contract(&env);
+
+    let result = client.try_migrate(&admin, &1);
+    assert_eq!(result, Err(Ok(Error::InvalidVersion)));
+    assert_eq!(client.get_version(), 0);
+}
+
+#[test]
+fn test_migrate_initializes_missing_registry_and_guard_then_is_idempotent() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, _core_id, client) = create_contract(&env);
+
+    client.migrate(&admin, &0);
+
+    assert_eq!(client.get_all_pools().len(), 0);
+    assert_eq!(client.get_version(), CURRENT_VERSION);
+
+    let result = client.try_migrate(&admin, &CURRENT_VERSION);
+    assert_eq!(result, Err(Ok(Error::AlreadyMigrated)));
+    assert_eq!(client.get_version(), CURRENT_VERSION);
+}
+
+#[test]
+fn test_migrate_preserves_existing_pool_registry() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, _core_id, client) = create_contract(&env);
+
+    client.register_pool(&admin, &42, &RiskLevel::Medium, &900, &123_456);
+    client.migrate(&admin, &0);
+
+    let pools = client.get_all_pools();
+    assert_eq!(pools.len(), 1);
+    assert_eq!(pools.get(0).unwrap().pool_id, 42);
+    assert_eq!(client.get_version(), CURRENT_VERSION);
+}
+
+#[test]
+fn test_migrate_rejects_non_admin() {
+    let env = Env::default();
+    env.mock_all_auths();
+    let (admin, _core_id, client) = create_contract(&env);
+    let non_admin = Address::generate(&env);
+
+    let result = client.try_migrate(&non_admin, &0);
+    assert_eq!(result, Err(Ok(Error::Unauthorized)));
+    assert_eq!(client.get_version(), 0);
+
+    client.migrate(&admin, &0);
+    assert_eq!(client.get_version(), CURRENT_VERSION);
 }
 
 // ============================================================================

--- a/contracts/attestation_engine/src/tests.rs
+++ b/contracts/attestation_engine/src/tests.rs
@@ -145,6 +145,90 @@ fn setup_initialized_engine_with_core(e: &Env) -> (Address, Address) {
 }
 
 #[test]
+fn test_migrate_rejects_wrong_from_version_without_mutating_state() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, AttestationEngineContract);
+    let client = AttestationEngineContractClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    let core = Address::generate(&e);
+
+    client.initialize(&admin, &core);
+
+    let result = client.try_migrate(&admin, &1);
+    assert_eq!(result, Err(Ok(AttestationError::InvalidVersion)));
+    assert_eq!(client.get_version(), 0);
+}
+
+#[test]
+fn test_migrate_initializes_missing_analytics_and_is_idempotent() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, AttestationEngineContract);
+    let client = AttestationEngineContractClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    let core = Address::generate(&e);
+
+    client.initialize(&admin, &core);
+    client.migrate(&admin, &0);
+
+    assert_eq!(client.get_version(), CURRENT_VERSION);
+    e.as_contract(&contract_id, || {
+        assert_eq!(e.storage().instance().get::<_, u64>(&DataKey::TotalAttestations), Some(0));
+        assert_eq!(e.storage().instance().get::<_, u64>(&DataKey::TotalViolations), Some(0));
+        assert_eq!(e.storage().instance().get::<_, i128>(&DataKey::TotalFees), Some(0));
+        assert_eq!(e.storage().instance().get::<_, bool>(&DataKey::ReentrancyGuard), Some(false));
+    });
+
+    let result = client.try_migrate(&admin, &CURRENT_VERSION);
+    assert_eq!(result, Err(Ok(AttestationError::AlreadyMigrated)));
+    assert_eq!(client.get_version(), CURRENT_VERSION);
+}
+
+#[test]
+fn test_migrate_preserves_existing_analytics_counters() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, AttestationEngineContract);
+    let client = AttestationEngineContractClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    let core = Address::generate(&e);
+
+    client.initialize(&admin, &core);
+    e.as_contract(&contract_id, || {
+        e.storage().instance().set(&DataKey::TotalAttestations, &7u64);
+        e.storage().instance().set(&DataKey::TotalViolations, &2u64);
+        e.storage().instance().set(&DataKey::TotalFees, &123i128);
+    });
+
+    client.migrate(&admin, &0);
+
+    e.as_contract(&contract_id, || {
+        assert_eq!(e.storage().instance().get::<_, u64>(&DataKey::TotalAttestations), Some(7));
+        assert_eq!(e.storage().instance().get::<_, u64>(&DataKey::TotalViolations), Some(2));
+        assert_eq!(e.storage().instance().get::<_, i128>(&DataKey::TotalFees), Some(123));
+    });
+    assert_eq!(client.get_version(), CURRENT_VERSION);
+}
+
+#[test]
+fn test_migrate_rejects_non_admin() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let contract_id = e.register_contract(None, AttestationEngineContract);
+    let client = AttestationEngineContractClient::new(&e, &contract_id);
+    let admin = Address::generate(&e);
+    let non_admin = Address::generate(&e);
+    let core = Address::generate(&e);
+
+    client.initialize(&admin, &core);
+
+    let result = client.try_migrate(&non_admin, &0);
+    assert_eq!(result, Err(Ok(AttestationError::Unauthorized)));
+    assert_eq!(client.get_version(), 0);
+}
+
+#[test]
 fn test_get_health_metrics_cross_reads_commitment_core_state() {
     let e = Env::default();
     let (attestation_id, core_id) = setup_initialized_engine_with_core(&e);

--- a/docs/UPGRADE_PATHS.md
+++ b/docs/UPGRADE_PATHS.md
@@ -12,3 +12,9 @@
 5. **Update off-chain metadata** if needed.
 
 For full details, see `docs/UPGRADES.md`.
+
+## Migration idempotency guarantees
+- `migrate(caller, from_version)` is admin-only and rejects non-admin callers before writing state.
+- `from_version` must match the stored `Version`; mismatches return `InvalidVersion` and leave `Version` unchanged.
+- After a successful migration, `Version` is set to the current contract version; repeat calls return `AlreadyMigrated` without changing stored data.
+- Migration initialises missing analytics/registry keys needed by the current version while preserving existing counters, pool registries, and allocation state.


### PR DESCRIPTION
Closes #484.\n\n## Summary\n- add migration version-guard/idempotency coverage for attestation_engine\n- add migration version-guard/idempotency coverage for allocation_logic\n- document migration idempotency guarantees in UPGRADE_PATHS\n\n## Tests\n- cargo test -p attestation_engine test_migrate -- --nocapture\n- cargo test -p allocation_logic test_migrate -- --nocapture\n\nNote: I also tried the issue-suggested ; it fails before project tests because  enables , which is not supported on the wasm target.