### PR TITLE
test: add tranche fee conservation coverage

### DIFF
--- a/contracts/commitment_transformation/src/tests.rs
+++ b/contracts/commitment_transformation/src/tests.rs
@@ -21,9 +21,11 @@
 #![cfg(test)]
 
 use super::*;
+use crate::mock_commitment_core::{
+    Commitment, CommitmentRules, MockCommitmentCore, MockCommitmentCoreClient,
+};
 use soroban_sdk::testutils::Address as _;
-use soroban_sdk::{vec, Address, Env, String, Vec};
-use crate::mock_commitment_core::{Commitment, CommitmentRules, MockCommitmentCore, MockCommitmentCoreClient};
+use soroban_sdk::{token::StellarAssetClient, vec, Address, Env, String, Vec};
 
 fn setup(e: &Env) -> (Address, Address, Address) {
     let admin = Address::generate(e);
@@ -38,6 +40,14 @@ fn deploy(e: &Env) -> (CommitmentTransformationContractClient<'_>, Address, Addr
     let client = CommitmentTransformationContractClient::new(e, &contract_id);
     client.initialize(&admin, &core);
     (client, admin, core, user)
+}
+
+fn setup_fee_asset(e: &Env, holder: &Address, balance: i128) -> Address {
+    let token_admin = Address::generate(e);
+    let token = e.register_stellar_asset_contract_v2(token_admin);
+    let asset = token.address();
+    StellarAssetClient::new(e, &asset).mint(holder, &balance);
+    asset
 }
 
 fn seed_commitment_owner(e: &Env, core: &Address, commitment_id: &str, owner: &Address) {
@@ -193,7 +203,14 @@ fn test_create_tranches_two_equal_halves() {
     ];
     let fee_asset = Address::generate(&e);
 
-    let id = client.create_tranches(&user, &commitment_id, &total_value, &bps, &levels, &fee_asset);
+    let id = client.create_tranches(
+        &user,
+        &commitment_id,
+        &total_value,
+        &bps,
+        &levels,
+        &fee_asset,
+    );
     let set = client.get_tranche_set(&id);
     assert_eq!(set.tranches.len(), 2);
     assert_eq!(set.tranches.get(0).unwrap().amount, 1_000_000i128);
@@ -255,7 +272,14 @@ fn test_create_tranches_four_tranches() {
     ];
     let fee_asset = Address::generate(&e);
 
-    let id = client.create_tranches(&user, &commitment_id, &total_value, &bps, &levels, &fee_asset);
+    let id = client.create_tranches(
+        &user,
+        &commitment_id,
+        &total_value,
+        &bps,
+        &levels,
+        &fee_asset,
+    );
     let set = client.get_tranche_set(&id);
     assert_eq!(set.tranches.len(), 4);
     assert_eq!(set.tranches.get(0).unwrap().amount, 400_000i128);
@@ -283,7 +307,14 @@ fn test_create_tranches_amounts_sum_to_net_value() {
     ];
     let fee_asset = Address::generate(&e);
 
-    let id = client.create_tranches(&user, &commitment_id, &total_value, &bps, &levels, &fee_asset);
+    let id = client.create_tranches(
+        &user,
+        &commitment_id,
+        &total_value,
+        &bps,
+        &levels,
+        &fee_asset,
+    );
     let set = client.get_tranche_set(&id);
 
     // Verify bps sum is exactly 10000
@@ -331,10 +362,99 @@ fn test_transformation_with_zero_fee() {
     let levels: Vec<String> = vec![&e, String::from_str(&e, "senior")];
     let fee_asset = Address::generate(&e);
 
-    let id = client.create_tranches(&user, &commitment_id, &total_value, &bps, &levels, &fee_asset);
+    let id = client.create_tranches(
+        &user,
+        &commitment_id,
+        &total_value,
+        &bps,
+        &levels,
+        &fee_asset,
+    );
     let set = client.get_tranche_set(&id);
     assert_eq!(set.fee_paid, 0i128);
     assert_eq!(set.total_value, total_value);
+}
+
+#[test]
+fn test_create_tranches_conserves_net_value_with_deterministic_dust() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin, _, user) = deploy(&e);
+    client.set_transformation_fee(&admin, &0);
+    client.set_authorized_transformer(&admin, &user, &true);
+
+    let commitment_id = String::from_str(&e, "c_dust");
+    let total_value = 1_000_003i128;
+    let bps: Vec<u32> = vec![&e, 3333u32, 3333u32, 3334u32];
+    let levels: Vec<String> = vec![
+        &e,
+        String::from_str(&e, "senior"),
+        String::from_str(&e, "mezzanine"),
+        String::from_str(&e, "equity"),
+    ];
+    let fee_asset = Address::generate(&e);
+
+    let id = client.create_tranches(
+        &user,
+        &commitment_id,
+        &total_value,
+        &bps,
+        &levels,
+        &fee_asset,
+    );
+    let set = client.get_tranche_set(&id);
+    let tranche_sum: i128 = set.tranches.iter().map(|tranche| tranche.amount).sum();
+    let net_value = total_value - set.fee_paid;
+    let dust = net_value - tranche_sum;
+
+    assert_eq!(set.fee_paid, 0);
+    assert_eq!(net_value, 1_000_003);
+    assert_eq!(tranche_sum, 1_000_001);
+    assert_eq!(dust, 2);
+    assert!(dust >= 0);
+    assert!(dust <= (set.tranches.len() as i128 - 1));
+    assert_eq!(tranche_sum + dust, net_value);
+}
+
+#[test]
+fn test_create_tranches_records_fee_and_conserves_net_value() {
+    let e = Env::default();
+    e.mock_all_auths();
+    let (client, admin, _, user) = deploy(&e);
+    client.set_transformation_fee(&admin, &125);
+    client.set_authorized_transformer(&admin, &user, &true);
+
+    let commitment_id = String::from_str(&e, "c_fee_conserve");
+    let total_value = 1_234_567i128;
+    let expected_fee = (total_value * 125i128) / 10_000i128;
+    let fee_asset = setup_fee_asset(&e, &user, expected_fee);
+    let bps: Vec<u32> = vec![&e, 5000u32, 3000u32, 2000u32];
+    let levels: Vec<String> = vec![
+        &e,
+        String::from_str(&e, "senior"),
+        String::from_str(&e, "mezzanine"),
+        String::from_str(&e, "equity"),
+    ];
+
+    let id = client.create_tranches(
+        &user,
+        &commitment_id,
+        &total_value,
+        &bps,
+        &levels,
+        &fee_asset,
+    );
+    let set = client.get_tranche_set(&id);
+    let net_value = total_value - expected_fee;
+    let tranche_sum: i128 = set.tranches.iter().map(|tranche| tranche.amount).sum();
+    let dust = net_value - tranche_sum;
+
+    assert_eq!(set.fee_paid, expected_fee);
+    assert_eq!(client.get_collected_fees(&fee_asset), expected_fee);
+    assert_eq!(dust, 1);
+    assert!(dust >= 0);
+    assert!(dust <= (set.tranches.len() as i128 - 1));
+    assert_eq!(tranche_sum + dust, net_value);
 }
 
 // ============================================================================

--- a/docs/FEE_MODEL_CROSS_CHECK.md
+++ b/docs/FEE_MODEL_CROSS_CHECK.md
@@ -87,6 +87,20 @@ The previous version of this file listed commitment_core fee infrastructure as *
 
 No material discrepancies.
 
+### Tranche fee/dust invariants
+
+Regression tests in `contracts/commitment_transformation/src/tests.rs` pin the
+following properties for `create_tranches`:
+
+- accepted ratios must sum to exactly `10_000` bps; `9_999`, `10_001`, empty
+  vectors, and mismatched risk-level lengths are rejected;
+- `fee_paid == floor(total_value * TransformationFeeBps / 10_000)` and the same
+  amount is credited to `CollectedFees(asset)`;
+- tranche allocation conserves the post-fee net value as
+  `sum(tranche.amount) + dust == total_value - fee_paid`; and
+- integer-division dust is deterministic and bounded by
+  `0 <= dust <= tranche_count - 1`.
+
 ---
 
 ## `commitment_marketplace`

--- a/docs/RISK_TRANCHES.md
+++ b/docs/RISK_TRANCHES.md
@@ -156,6 +156,13 @@ Active ──────────────> Closed
 - All allocation calculations use **checked arithmetic**
 - Overflow/underflow results in `InvalidAmount` error
 - Negative allocations allowed (withdrawals) but cannot result in negative balance
+- `create_tranches()` requires tranche shares to be non-empty, match the number of
+  risk labels, and sum to exactly `10_000` basis points. Off-by-one totals such as
+  `9_999` or `10_001` are rejected before any tranche set is stored.
+- Tranche amounts are computed with integer floor division against the post-fee net
+  value. The unallocated rounding dust is deterministic and bounded by
+  `0 <= dust <= tranche_count - 1`, with
+  `sum(tranche.amount) + dust == total_value - fee_paid`.
 
 ### Reentrancy Protection
 
@@ -187,6 +194,12 @@ let transformation_id = client.create_tranches(
     &fee_asset,
 );
 ```
+
+For non-round values, callers should treat the tranche set as conserving the
+post-fee net value plus explicit dust rather than expecting every stroop to be
+allocated to a tranche. Example: with `1_000_003` net units and
+`3333/3333/3334` bps, tranche allocation totals `1_000_001` and leaves `2`
+units of bounded rounding dust.
 
 ### Accessing Individual Tranches
 


### PR DESCRIPTION
## Summary
- add deterministic create_tranches dust-conservation coverage
- assert fee accumulation into CollectedFees(asset) matches floor(total_value * fee_bps / 10000)
- document tranche ratio, fee, and bounded rounding-dust invariants

Closes #483

## Validation
- ✅ `cargo test -p commitment_transformation` (66 passed)
- ✅ `git diff --check`
- ⚠️ `cargo test --target wasm32v1-none --release -p commitment_transformation -- --nocapture` currently fails locally with `E0463: can't find crate for test` because this invokes Rust unit-test harness compilation for the no_std wasm target; no private artifacts included.
