### PR TITLE
fix: check creation fee arithmetic

### DIFF
--- a/contracts/commitment_core/src/fee_tests.rs
+++ b/contracts/commitment_core/src/fee_tests.rs
@@ -9,7 +9,7 @@
 
 #![cfg(test)]
 
-use crate::{CommitmentCoreContract, CommitmentCoreContractClient, CommitmentRules};
+use crate::{fuzzing, CommitmentCoreContract, CommitmentCoreContractClient, CommitmentRules};
 use soroban_sdk::{
     contract, contractimpl,
     testutils::{Address as _, Ledger},
@@ -239,6 +239,22 @@ fn test_create_commitment_with_max_fee() {
 
     // Verify all amount was collected as fee
     assert_eq!(client.get_collected_fees(&token_address), expected_fee);
+}
+
+#[test]
+fn test_checked_creation_fee_boundaries() {
+    assert_eq!(fuzzing::checked_fee_from_bps(1_000_000, 0), Some(0));
+    assert_eq!(
+        fuzzing::checked_fee_from_bps(1_000_000, 10_000),
+        Some(1_000_000)
+    );
+
+    let near_overflow_amount = i128::MAX / 10_000;
+    assert_eq!(
+        fuzzing::checked_fee_from_bps(near_overflow_amount, 10_000),
+        Some(near_overflow_amount)
+    );
+    assert_eq!(fuzzing::checked_fee_from_bps(i128::MAX, 2), None);
 }
 
 #[test]

--- a/contracts/commitment_core/src/fuzz_tests.rs
+++ b/contracts/commitment_core/src/fuzz_tests.rs
@@ -138,4 +138,12 @@ fn test_create_commitment_rejects_fee_math_overflow() {
     assert_eq!(client.get_total_commitments(), 0);
     assert_eq!(client.get_total_value_locked(), 0);
     assert_eq!(client.get_collected_fees(&asset_address), 0);
+
+    client.set_creation_fee_bps(&admin, &0);
+    let retry_amount = 1_000i128;
+    let retry =
+        client.try_create_commitment(&owner, &retry_amount, &asset_address, &default_rules(&e));
+
+    assert!(retry.is_ok());
+    assert_eq!(client.get_total_commitments(), 1);
 }

--- a/contracts/commitment_core/src/lib.rs
+++ b/contracts/commitment_core/src/lib.rs
@@ -477,6 +477,9 @@ impl CommitmentCoreContract {
     /// 4. transfer tokens into this contract
     /// 5. invoke `commitment_nft::mint`
     ///
+    /// Creation fee math uses `fuzzing::checked_fee_from_bps` as the single
+    /// checked source of truth so arithmetic overflow maps to `ArithmeticOverflow`.
+    ///
     /// Because Soroban reverts the entire invocation on panic, a downstream NFT mint
     /// failure should roll back the earlier state writes and token transfer.
     pub fn create_commitment(
@@ -504,11 +507,11 @@ impl CommitmentCoreContract {
             .instance()
             .get(&DataKey::CreationFeeBps)
             .unwrap_or(0);
-        let creation_fee = if creation_fee_bps > 0 {
-            fees::fee_from_bps(amount, creation_fee_bps)
-        } else {
-            0
-        };
+        let creation_fee =
+            fuzzing::checked_fee_from_bps(amount, creation_fee_bps).unwrap_or_else(|| {
+                set_reentrancy_guard(&e, false);
+                fail(&e, CommitmentError::ArithmeticOverflow, "create");
+            });
         let net_amount = amount.checked_sub(creation_fee).unwrap_or_else(|| {
             set_reentrancy_guard(&e, false);
             fail(&e, CommitmentError::ArithmeticOverflow, "create");

--- a/docs/FEES.md
+++ b/docs/FEES.md
@@ -68,7 +68,7 @@ Both round toward zero (floor for positive values). The sum of tranche amounts c
 
 | Fee | When | Calculation | Token flow |
 |-----|------|-------------|------------|
-| Creation | `create_commitment` | `fees::fee_from_bps(amount, CreationFeeBps)`; default bps `0` | Owner transfers full `amount` to contract; `creation_fee` credited to `CollectedFees(asset_address)`; NFT minted with `net_amount = amount - creation_fee`; TVL incremented by `net_amount` |
+| Creation | `create_commitment` | `fuzzing::checked_fee_from_bps(amount, CreationFeeBps)`; default bps `0` | Owner transfers full `amount` to contract; `creation_fee` credited to `CollectedFees(asset_address)`; NFT minted with `net_amount = amount - creation_fee`; TVL incremented by `net_amount` |
 | Early exit | `early_exit` | `SafeMath::penalty_amount(current_value, rules.early_exit_penalty)` | Penalty added to `CollectedFees(asset)`; `returned = current_value - penalty` transferred to owner when `returned > 0` |
 
 #### Storage keys

--- a/docs/FEE_MODEL_CROSS_CHECK.md
+++ b/docs/FEE_MODEL_CROSS_CHECK.md
@@ -79,7 +79,7 @@ The previous version of this file listed commitment_core fee infrastructure as *
 | `TransformationFeeBps` | Yes | `DataKey::TransformationFeeBps`, default `0` at init | ✅ |
 | `CollectedFees(asset)` | Yes | Credited in `create_tranches` | ✅ |
 | `FeeRecipient` | Yes | `set_fee_recipient` | ✅ |
-| Fee formula | `(total_value * bps) / 10_000` via `fees::fee_from_bps` | Lines ~529–543 | ✅ |
+| Fee formula | `(total_value * bps) / 10_000` via `fuzzing::checked_fee_from_bps` | Lines ~529–543 | ✅ |
 | Rounding / dust | Floor toward zero; tranche dust documented | Module docs lines ~27–35 | ✅ |
 | `set_transformation_fee` | 0–10000 bps | `fee_bps > 10000` → `InvalidFeeBps` | ✅ |
 | `withdraw_fees` | Admin, ledger cap | Lines ~1009–1031 | ✅ |
@@ -133,7 +133,8 @@ Prior `docs/FEES.md` listed marketplace fees as "TBD". They are now documented a
 | Item | `shared_utils::fees` | Used by |
 |------|---------------------|---------|
 | `BPS_SCALE` / `BPS_MAX` = 10_000 | `fees.rs` | `commitment_core`, `commitment_transformation` |
-| `fee_from_bps` — floor division | `fees.rs` | Creation, transformation fees |
+| `checked_fee_from_bps` — checked floor division | `commitment_core::fuzzing` | Creation fees |
+| `fee_from_bps` — floor division | `fees.rs` | Transformation fees |
 | `SafeMath::penalty_amount` — percent ÷ 100 | `math.rs` | `commitment_core::early_exit` |
 | `SafeMath::div(mul(price, bps), 10_000)` | `math.rs` | `commitment_marketplace` listings/auctions |
 


### PR DESCRIPTION
## Summary
- Route `commitment_core::create_commitment` creation-fee math through the checked fee helper instead of the unchecked `fees::fee_from_bps` path.
- Reset the reentrancy guard and return the contract's `ArithmeticOverflow` failure path when fee multiplication overflows.
- Add boundary coverage for 0 bps, 10000 bps, near-overflow valid input, and overflow rejection followed by a successful retry.
- Update fee docs to point creation-fee accounting at the checked helper.

Closes #490.

## Notes
The current `master` branch no longer has a second shadowing creation-fee block, but `create_commitment` still used the unchecked fee helper. This PR keeps the issue's safety intent by making the remaining creation-fee calculation the single checked source of truth.

## Verification
- `cargo test -p commitment_core test_checked_creation_fee_boundaries`
- `cargo test -p commitment_core test_create_commitment_rejects_fee_math_overflow`
- `cargo build -p commitment_core --target wasm32v1-none --release`
- `git diff --check`

## Known existing verification limits
- `cargo test -p commitment_core` currently fails 3 unrelated tests on `master` behavior:
  - `emergency_tests::test_emergency_mode_toggle_emits_events` expects 2 events and receives 3.
  - `tests::test_create_commitment_event` fails an event topic assertion.
  - `tests::test_create_commitment_updates_storage_layout` expects `c_0` and receives `COMMIT_0`.
- `cargo test --target wasm32v1-none --release` fails before contract compilation because `soroban-sdk` is built with `testutils`, and `testutils` is explicitly unsupported on wasm targets. The release wasm build for `commitment_core` passes.
