### PR TITLE
test: add core fee fuzz invariants

### DIFF
--- a/contracts/commitment_core/src/fuzz_tests.rs
+++ b/contracts/commitment_core/src/fuzz_tests.rs
@@ -2,8 +2,8 @@
 
 use crate::{
     fuzzing::{
-        classify_generated_commitment_id_bytes, observe_amount, observe_commitment_input,
-        AmountShape, CommitmentIdShape,
+        checked_fee_and_net_from_bps, checked_fee_from_bps, classify_generated_commitment_id_bytes,
+        observe_amount, observe_commitment_input, AmountShape, CommitmentIdShape,
     },
     CommitmentCoreContract, CommitmentCoreContractClient, CommitmentRules,
 };
@@ -88,7 +88,16 @@ fn test_fuzz_amount_seed_shapes() {
     assert_eq!(observe_amount(0, 0).shape, AmountShape::NonPositive);
     assert_eq!(observe_amount(-1, 0).shape, AmountShape::NonPositive);
     assert_eq!(observe_amount(1, 10_001).shape, AmountShape::InvalidFeeBps);
-    assert_eq!(observe_amount(i128::MAX, 2).shape, AmountShape::FeeOverflow);
+
+    let max_small_fee = observe_amount(i128::MAX, 2);
+    assert_eq!(max_small_fee.shape, AmountShape::Valid);
+    assert_eq!(
+        max_small_fee
+            .net
+            .unwrap()
+            .checked_add(max_small_fee.fee.unwrap()),
+        Some(i128::MAX)
+    );
 
     let max_fee = observe_amount(1, 10_000);
     assert_eq!(max_fee.shape, AmountShape::Valid);
@@ -99,6 +108,55 @@ fn test_fuzz_amount_seed_shapes() {
     assert_eq!(normal.shape, AmountShape::Valid);
     assert_eq!(normal.fee, Some(10));
     assert_eq!(normal.net, Some(990));
+}
+
+#[test]
+fn test_fee_and_net_seed_cases_conserve_value() {
+    let cases = [
+        (0i128, 0u32),
+        (0, 10_000),
+        (1, 0),
+        (1, 1),
+        (1, 10_000),
+        (9_999, 9_999),
+        (10_000, 10_000),
+        (1_000_000, 250),
+        (i128::MAX - 10_000, 1),
+        (i128::MAX - 9_999, 9_999),
+        (i128::MAX - 1, 5_000),
+        (i128::MAX, 0),
+        (i128::MAX, 1),
+        (i128::MAX, 10_000),
+    ];
+
+    for (amount, bps) in cases {
+        let (fee, net) = checked_fee_and_net_from_bps(amount, bps)
+            .expect("valid amount and bps should produce fee and net");
+        assert!(
+            fee >= 0,
+            "fee must be non-negative for amount={amount} bps={bps}"
+        );
+        assert!(
+            net >= 0,
+            "net must be non-negative for amount={amount} bps={bps}"
+        );
+        assert!(
+            fee <= amount,
+            "fee must not exceed amount={amount} bps={bps}"
+        );
+        assert_eq!(
+            net.checked_add(fee),
+            Some(amount),
+            "net + fee must exactly conserve amount={amount} bps={bps}"
+        );
+        assert_eq!(checked_fee_from_bps(amount, bps), Some(fee));
+    }
+}
+
+#[test]
+fn test_fee_and_net_rejects_invalid_bps() {
+    assert_eq!(checked_fee_from_bps(1_000, 10_001), None);
+    assert_eq!(checked_fee_and_net_from_bps(1_000, 10_001), None);
 }
 
 #[test]

--- a/contracts/commitment_core/src/fuzzing.rs
+++ b/contracts/commitment_core/src/fuzzing.rs
@@ -72,9 +72,20 @@ pub fn checked_fee_from_bps(amount: i128, fee_bps: u32) -> Option<i128> {
         return None;
     }
 
-    amount
-        .checked_mul(fee_bps as i128)?
-        .checked_div(BPS_SCALE as i128)
+    let scale = BPS_SCALE as i128;
+    let bps = fee_bps as i128;
+    let whole = amount.checked_div(scale)?.checked_mul(bps)?;
+    let fractional = amount
+        .checked_rem(scale)?
+        .checked_mul(bps)?
+        .checked_div(scale)?;
+    whole.checked_add(fractional)
+}
+
+pub fn checked_fee_and_net_from_bps(amount: i128, fee_bps: u32) -> Option<(i128, i128)> {
+    let fee = checked_fee_from_bps(amount, fee_bps)?;
+    let net = amount.checked_sub(fee)?;
+    Some((fee, net))
 }
 
 pub fn observe_amount(amount: i128, fee_bps: u32) -> AmountObservation {

--- a/docs/SECURITY_AUDIT_PREP.md
+++ b/docs/SECURITY_AUDIT_PREP.md
@@ -27,6 +27,9 @@
 - Access control enforcement for privileged paths
 - Reentrancy guard usage and guard cleanup on error paths
 - Arithmetic safety and overflow behavior
+  - Fee fuzz helpers assert `0 <= fee <= amount` and `net + fee == amount`
+    for deterministic boundary seeds, including `i128::MAX`-adjacent values
+    and `bps = 10000`.
 - Cross-contract calls (token transfer, NFT mint/settle, commitment_core reads)
 - Storage growth and data consistency for vectors and registries
 


### PR DESCRIPTION
Closes #486.

## Summary

- make the deterministic fuzz helper calculate bps fees without overflowing on `i128::MAX`-adjacent inputs
- add `checked_fee_and_net_from_bps` so fuzz/property tests can assert value conservation directly
- add deterministic seed coverage for `fee <= amount`, `net + fee == amount`, `bps = 0`, `bps = 10000`, invalid bps, and `i128::MAX` boundaries
- document the audited fee/value invariants in `docs/SECURITY_AUDIT_PREP.md`

This stays scoped to the fuzz helper/test surface and does not change the production `commitment_core::create_commitment` path.

## Verification

- `cargo test -p commitment_core fuzz --lib`
- `cargo build -p commitment_core --target wasm32v1-none --release`
- `git diff --check`

Focused fuzz output:

```text
running 7 tests
test fuzz_tests::test_fee_and_net_rejects_invalid_bps ... ok
test fuzz_tests::test_fuzz_commitment_id_rejects_oversized_seed ... ok
test fuzz_tests::test_fuzz_commitment_id_seed_shapes ... ok
test fuzz_tests::test_fuzz_observation_combines_id_and_amount_seed ... ok
test fuzz_tests::test_fuzz_amount_seed_shapes ... ok
test fuzz_tests::test_fee_and_net_seed_cases_conserve_value ... ok
test fuzz_tests::test_create_commitment_rejects_fee_math_overflow ... ok
```

I also ran `cargo test -p commitment_core --lib`; the new fuzz tests passed, but the full package still has three pre-existing failures unrelated to this change:

- `emergency_tests::test_emergency_mode_toggle_emits_events`
- `tests::test_create_commitment_event`
- `tests::test_create_commitment_updates_storage_layout`

The command reported 164 passed and 3 failed before stopping.
