### PR TITLE
fix: return typed oracle errors for auth helpers

### DIFF
--- a/contracts/price_oracle/src/lib.rs
+++ b/contracts/price_oracle/src/lib.rs
@@ -17,7 +17,7 @@
 //! for their asset and risk model. See:
 //! [`docs/THREAT_MODEL.md#price-oracle-manipulation-resistance-assumptions`](../../../docs/THREAT_MODEL.md#price-oracle-manipulation-resistance-assumptions)
 
-use shared_utils::{Validation, SafeMath};
+use shared_utils::{SafeMath, Validation};
 use soroban_sdk::{
     contract, contracterror, contractimpl, contracttype, symbol_short, Address, BytesN, Env, Vec,
 };
@@ -76,13 +76,16 @@ pub enum DataKey {
     Version,
 }
 
-fn read_admin(e: &Env) -> Address {
+/// Read the configured admin address.
+///
+/// Returns `OracleError::NotInitialized` instead of panicking so off-chain
+/// callers can decode the same typed error shape used by state-changing paths.
+fn read_admin(e: &Env) -> Result<Address, OracleError> {
     e.storage()
         .instance()
         .get::<_, Address>(&DataKey::Admin)
-        .unwrap_or_else(|| panic!("Contract not initialized"))
+        .ok_or(OracleError::NotInitialized)
 }
-
 
 fn is_whitelisted(e: &Env, addr: &Address) -> bool {
     e.storage()
@@ -91,11 +94,17 @@ fn is_whitelisted(e: &Env, addr: &Address) -> bool {
         .unwrap_or(false)
 }
 
-fn require_whitelisted(e: &Env, caller: &Address) {
+/// Require a signed call from a whitelisted oracle publisher.
+///
+/// Non-whitelisted publishers return `OracleError::OracleNotWhitelisted`
+/// rather than a bare panic string, preserving the existing failure condition
+/// while making it machine-decodable.
+fn require_whitelisted(e: &Env, caller: &Address) -> Result<(), OracleError> {
     caller.require_auth();
     if !is_whitelisted(e, caller) {
-        panic!("Oracle not whitelisted");
+        return Err(OracleError::OracleNotWhitelisted);
     }
+    Ok(())
 }
 
 fn read_version(e: &Env) -> u32 {
@@ -249,7 +258,7 @@ impl PriceOracleContract {
         price: i128,
         decimals: u32,
     ) -> Result<(), OracleError> {
-        require_whitelisted(&e, &caller);
+        require_whitelisted(&e, &caller)?;
         Validation::require_non_negative(price);
         let updated_at = e.ledger().timestamp();
         let data = PriceData {
@@ -336,7 +345,7 @@ impl PriceOracleContract {
     /// @dev View function.
     /// @param e Contract environment.
     /// @return Address of the current admin.
-    pub fn get_admin(e: Env) -> Address {
+    pub fn get_admin(e: Env) -> Result<Address, OracleError> {
         read_admin(&e)
     }
 
@@ -407,21 +416,21 @@ impl PriceOracleContract {
     // ========================================================================
 
     /// Get price with consumer-level validation for commitment_core contracts.
-    /// 
+    ///
     /// This function provides stricter validation suitable for financial commitment contracts:
     /// - Enforces maximum staleness of 300 seconds (5 minutes) for commitment operations
     /// - Validates price is positive and within reasonable bounds
     /// - Returns detailed error information for consumer contract handling
-    /// 
+    ///
     /// # Parameters
     /// * `asset` - The asset address to get price for
     /// * `max_price_variation_percent` - Optional maximum allowed price variation (0-100)
     ///   If provided, validates that price hasn't changed more than this percentage
     ///   from the previous price (if available)
-    /// 
+    ///
     /// # Returns
     /// `Result<PriceData, OracleError>` - Price data if valid, error otherwise
-    /// 
+    ///
     /// # Security Notes
     /// - Consumers should use this instead of get_price() for financial operations
     /// - 5-minute staleness limit balances freshness with oracle reliability
@@ -448,16 +457,14 @@ impl PriceOracleContract {
             }
 
             // Get previous price for comparison (if available)
-            let previous_data = e.storage().instance().get::<_, PriceData>(
-                &DataKey::Price(asset.clone())
-            );
+            let previous_data = e
+                .storage()
+                .instance()
+                .get::<_, PriceData>(&DataKey::Price(asset.clone()));
 
             if let Some(prev) = previous_data {
                 if prev.updated_at < data.updated_at && prev.price > 0 {
-                    let variation = SafeMath::calculate_percentage_change(
-                        prev.price,
-                        data.price
-                    );
+                    let variation = SafeMath::calculate_percentage_change(prev.price, data.price);
                     if variation > max_variation as i128 {
                         // Price variation too high - potential manipulation
                         return Err(OracleError::StalePrice); // Reuse error for variation check
@@ -470,20 +477,20 @@ impl PriceOracleContract {
     }
 
     /// Get price with consumer-level validation for marketplace contracts.
-    /// 
+    ///
     /// This function provides validation suitable for marketplace operations:
     /// - Allows longer staleness (1800 seconds = 30 minutes) for marketplace listings
     /// - Validates price is positive and reasonable for marketplace operations
     /// - Includes marketplace-specific price sanity checks
-    /// 
+    ///
     /// # Parameters
     /// * `asset` - The asset address to get price for
     /// * `min_price_usd` - Optional minimum USD price (in 8 decimals) for asset validation
     ///   Useful for preventing zero-price or manipulated low-price listings
-    /// 
+    ///
     /// # Returns
     /// `Result<PriceData, OracleError>` - Price data if valid, error otherwise
-    /// 
+    ///
     /// # Security Notes
     /// - 30-minute staleness allows for marketplace operational flexibility
     /// - Minimum price checks prevent zero-price attacks on listings
@@ -507,7 +514,7 @@ impl PriceOracleContract {
             if min_price <= 0 {
                 return Err(OracleError::InvalidPrice);
             }
-            
+
             // Convert oracle price to 8 decimals for comparison if needed
             let oracle_price_8dec = if data.decimals == 8 {
                 data.price
@@ -526,17 +533,17 @@ impl PriceOracleContract {
     }
 
     /// Batch price validation for multiple assets (useful for commitment_core operations).
-    /// 
+    ///
     /// Validates prices for multiple assets in a single call, reducing cross-contract
     /// call overhead for consumers that need multiple asset prices.
-    /// 
+    ///
     /// # Parameters
     /// * `assets` - Vector of asset addresses to get prices for
     /// * `max_staleness_seconds` - Maximum allowed staleness for all assets
-    /// 
+    ///
     /// # Returns
     /// `Result<Vec<(Address, PriceData)>, OracleError>` - Vector of (asset, price_data) tuples
-    /// 
+    ///
     /// # Security Notes
     /// - All assets must pass freshness validation for the batch to succeed
     /// - Consumers should handle partial failure scenarios appropriately
@@ -547,31 +554,32 @@ impl PriceOracleContract {
         max_staleness_seconds: u64,
     ) -> Result<Vec<(Address, PriceData)>, OracleError> {
         let mut results = Vec::new(&e);
-        
+
         for asset in assets.iter() {
-            let data = Self::get_price_valid(e.clone(), asset.clone(), Some(max_staleness_seconds))?;
+            let data =
+                Self::get_price_valid(e.clone(), asset.clone(), Some(max_staleness_seconds))?;
             results.push_back((asset.clone(), data));
         }
-        
+
         Ok(results)
     }
 
     /// Get price with safety checks for high-value operations.
-    /// 
+    ///
     /// Provides enhanced validation for operations involving significant value:
     /// - Stricter staleness requirements (60 seconds for high-value ops)
     /// - Price deviation checks against historical averages
     /// - Additional validation for critical financial operations
-    /// 
+    ///
     /// # Parameters
     /// * `asset` - The asset address to get price for
     /// * `operation_value_usd` - The USD value of the operation (in 8 decimals)
     ///   Used to determine appropriate validation strictness
     /// * `max_deviation_percent` - Maximum allowed deviation from historical average
-    /// 
+    ///
     /// # Returns
     /// `Result<PriceData, OracleError>` - Price data if valid, error otherwise
-    /// 
+    ///
     /// # Security Notes
     /// - High-value operations require fresher price data
     /// - Historical deviation checks prevent manipulation attacks
@@ -583,9 +591,11 @@ impl PriceOracleContract {
         max_deviation_percent: u32,
     ) -> Result<PriceData, OracleError> {
         // Dynamic staleness based on operation value
-        let staleness = if operation_value_usd > 100_000_000_000 { // > $1,000 USD in 8 decimals
+        let staleness = if operation_value_usd > 100_000_000_000 {
+            // > $1,000 USD in 8 decimals
             60 // 1 minute for very high value
-        } else if operation_value_usd > 10_000_000_000 { // > $100 USD in 8 decimals
+        } else if operation_value_usd > 10_000_000_000 {
+            // > $100 USD in 8 decimals
             300 // 5 minutes for high value
         } else {
             900 // 15 minutes for normal value
@@ -601,21 +611,21 @@ impl PriceOracleContract {
         // For very high-value operations, we could implement additional checks
         // such as requiring multiple oracle confirmations or circuit breakers
         if operation_value_usd > 1_000_000_000_000 { // > $10,000 USD
-            // In a production system, this might trigger additional validation
-            // such as checking against multiple price sources or requiring admin confirmation
+             // In a production system, this might trigger additional validation
+             // such as checking against multiple price sources or requiring admin confirmation
         }
 
         Ok(data)
     }
 
     /// Validate oracle health and status for consumer contracts.
-    /// 
+    ///
     /// Provides health information that consumer contracts can use to determine
     /// if the oracle system is operating normally.
-    /// 
+    ///
     /// # Returns
     /// `Result<OracleHealth, OracleError>` - Oracle health status
-    /// 
+    ///
     /// # Security Notes
     /// - Consumer contracts should check health before critical operations
     /// - Degraded health status should trigger fallback mechanisms
@@ -623,17 +633,17 @@ impl PriceOracleContract {
     pub fn get_oracle_health(e: Env) -> Result<OracleHealth, OracleError> {
         let config = read_config(&e);
         let current_time = e.ledger().timestamp();
-        
+
         // Check if we have any recent price updates
         let all_prices_recent = true; // In a real implementation, would scan recent prices
-        
+
         let health = OracleHealth {
             is_healthy: all_prices_recent,
             max_staleness_seconds: config.max_staleness_seconds,
             last_check: current_time,
             active_oracles_count: 0, // Would need to track active oracles
         };
-        
+
         Ok(health)
     }
 }

--- a/contracts/price_oracle/src/tests.rs
+++ b/contracts/price_oracle/src/tests.rs
@@ -14,12 +14,18 @@ fn test_admin_only_add_remove_oracle() {
     });
 
     // Only admin can add
-    assert_eq!(client.try_add_oracle(&not_admin, &oracle1), Err(Ok(OracleError::Unauthorized)));
+    assert_eq!(
+        client.try_add_oracle(&not_admin, &oracle1),
+        Err(Ok(OracleError::Unauthorized))
+    );
     assert_eq!(client.try_add_oracle(&admin, &oracle1), Ok(Ok(())));
     assert!(client.is_oracle_whitelisted(&oracle1));
 
     // Only admin can remove
-    assert_eq!(client.try_remove_oracle(&not_admin, &oracle1), Err(Ok(OracleError::Unauthorized)));
+    assert_eq!(
+        client.try_remove_oracle(&not_admin, &oracle1),
+        Err(Ok(OracleError::Unauthorized))
+    );
     assert_eq!(client.try_remove_oracle(&admin, &oracle1), Ok(Ok(())));
     assert!(!client.is_oracle_whitelisted(&oracle1));
 
@@ -48,21 +54,29 @@ fn test_admin_transfer_and_oracle_control() {
     });
 
     // Only admin1 can add
-    assert_eq!(client.try_add_oracle(&admin2, &oracle), Err(Ok(OracleError::Unauthorized)));
+    assert_eq!(
+        client.try_add_oracle(&admin2, &oracle),
+        Err(Ok(OracleError::Unauthorized))
+    );
     assert_eq!(client.try_add_oracle(&admin1, &oracle), Ok(Ok(())));
     assert!(client.is_oracle_whitelisted(&oracle));
 
     // Transfer admin
-    assert_eq!(client.try_set_admin(&admin2, &admin2), Err(Ok(OracleError::Unauthorized)));
+    assert_eq!(
+        client.try_set_admin(&admin2, &admin2),
+        Err(Ok(OracleError::Unauthorized))
+    );
     assert_eq!(client.try_set_admin(&admin1, &admin2), Ok(Ok(())));
     assert_eq!(client.get_admin(), admin2);
 
     // Now only admin2 can remove
-    assert_eq!(client.try_remove_oracle(&admin1, &oracle), Err(Ok(OracleError::Unauthorized)));
+    assert_eq!(
+        client.try_remove_oracle(&admin1, &oracle),
+        Err(Ok(OracleError::Unauthorized))
+    );
     assert_eq!(client.try_remove_oracle(&admin2, &oracle), Ok(Ok(())));
     assert!(!client.is_oracle_whitelisted(&oracle));
 }
-
 
 use super::*;
 use soroban_sdk::testutils::{Address as _, Ledger};
@@ -147,8 +161,7 @@ fn test_set_price_whitelisted() {
 }
 
 #[test]
-#[should_panic(expected = "Oracle not whitelisted")]
-fn test_set_price_unauthorized_fails() {
+fn test_set_price_non_whitelisted_returns_typed_error() {
     let e = Env::default();
     e.mock_all_auths();
     let admin = Address::generate(&e);
@@ -161,7 +174,19 @@ fn test_set_price_unauthorized_fails() {
         PriceOracleContract::initialize(e.clone(), admin.clone()).unwrap();
     });
 
-    client.set_price(&unauthorized, &asset, &1000, &8);
+    assert_eq!(
+        client.try_set_price(&unauthorized, &asset, &1000, &8),
+        Err(Ok(OracleError::OracleNotWhitelisted))
+    );
+}
+
+#[test]
+fn test_get_admin_uninitialized_returns_typed_error() {
+    let e = Env::default();
+    let contract_id = e.register_contract(None, PriceOracleContract);
+    let client = PriceOracleContractClient::new(&e, &contract_id);
+
+    assert_eq!(client.try_get_admin(), Err(Ok(OracleError::NotInitialized)));
 }
 
 #[test]
@@ -672,7 +697,7 @@ fn test_get_price_for_commitment_fresh() {
     });
 
     client.set_price(&oracle, &asset, &1000_00000000, &8);
-    
+
     // Should succeed with fresh price (within 5 minutes)
     let data = client.get_price_for_commitment(&asset, &Some(10)); // 10% max variation
     assert_eq!(data.price, 1000_00000000);
@@ -696,7 +721,7 @@ fn test_get_price_for_commitment_stale() {
     });
 
     client.set_price(&oracle, &asset, &1000_00000000, &8);
-    
+
     // Advance time past 5 minutes (300 seconds)
     e.ledger().with_mut(|li| {
         li.timestamp += 301;
@@ -749,7 +774,7 @@ fn test_get_price_for_marketplace_valid() {
     });
 
     client.set_price(&oracle, &asset, &50_00000000, &8); // $50 USD in 8 decimals
-    
+
     // Should succeed with price above minimum
     let data = client.get_price_for_marketplace(&asset, &Some(10_00000000)); // $10 minimum
     assert_eq!(data.price, 50_00000000);
@@ -773,7 +798,7 @@ fn test_get_price_for_marketplace_below_minimum() {
     });
 
     client.set_price(&oracle, &asset, &5_00000000, &8); // $5 USD in 8 decimals
-    
+
     // Should fail due to price below minimum
     let _ = client.get_price_for_marketplace(&asset, &Some(10_00000000)); // $10 minimum
 }
@@ -795,7 +820,7 @@ fn test_get_price_for_marketplace_different_decimals() {
 
     // Set price in 6 decimals ($100 USD = 100_000000)
     client.set_price(&oracle, &asset, &100_000000, &6);
-    
+
     // Should succeed when converting to 8 decimals for minimum check
     let data = client.get_price_for_marketplace(&asset, &Some(50_00000000)); // $50 minimum
     assert_eq!(data.price, 100_000000);
@@ -832,7 +857,7 @@ fn test_get_batch_prices_success() {
     // Should succeed with all fresh prices
     let results = client.get_batch_prices(&assets, &600); // 10 minutes max staleness
     assert_eq!(results.len(), 3);
-    
+
     // Verify results
     for (asset, data) in results.iter() {
         if asset == asset1 {
@@ -868,13 +893,13 @@ fn test_get_batch_prices_one_stale() {
     // Set prices
     client.set_price(&oracle, &asset1, &1000_00000000, &8);
     client.set_price(&oracle, &asset2, &2000_00000000, &8);
-    
+
     // Advance time and update only one price
     e.ledger().with_mut(|li| {
         li.timestamp += 120; // 2 minutes
     });
     client.set_price(&oracle, &asset2, &2100_00000000, &8);
-    
+
     // Advance time past batch staleness limit
     e.ledger().with_mut(|li| {
         li.timestamp += 500; // Total > 10 minutes
@@ -904,12 +929,12 @@ fn test_get_price_high_value_normal_value() {
     });
 
     client.set_price(&oracle, &asset, &1000_00000000, &8);
-    
+
     // Normal value operation ($50 USD) should use 15-minute staleness
     let data = client.get_price_high_value(
-        &asset, 
+        &asset,
         &50_00000000, // $50 USD in 8 decimals
-        &10 // 10% max deviation
+        &10,          // 10% max deviation
     );
     assert_eq!(data.price, 1000_00000000);
 }
@@ -930,12 +955,12 @@ fn test_get_price_high_value_high_value() {
     });
 
     client.set_price(&oracle, &asset, &1000_00000000, &8);
-    
+
     // High value operation ($2000 USD) should use 5-minute staleness
     let data = client.get_price_high_value(
-        &asset, 
+        &asset,
         &200_000_000_000, // $2000 USD in 8 decimals
-        &10 // 10% max deviation
+        &10,              // 10% max deviation
     );
     assert_eq!(data.price, 1000_00000000);
 }
@@ -957,7 +982,7 @@ fn test_get_price_high_value_very_high_value_stale() {
     });
 
     client.set_price(&oracle, &asset, &1000_00000000, &8);
-    
+
     // Advance time past 1 minute (very high value requires 1-minute freshness)
     e.ledger().with_mut(|li| {
         li.timestamp += 61;
@@ -965,9 +990,9 @@ fn test_get_price_high_value_very_high_value_stale() {
 
     // Very high value operation ($20000 USD) should fail with stale price
     let _ = client.get_price_high_value(
-        &asset, 
+        &asset,
         &2_000_000_000_000, // $20000 USD in 8 decimals
-        &10 // 10% max deviation
+        &10,                // 10% max deviation
     );
 }
 
@@ -1048,14 +1073,14 @@ fn test_oracle_consumer_integration_scenario() {
     let eth_price = client.get_price_high_value(
         &eth_asset,
         &commitment_value,
-        &5 // 5% max deviation
+        &5, // 5% max deviation
     );
     assert_eq!(eth_price.price, 3000_00000000);
 
     // Simulate marketplace listing with minimum price
     let usdc_price = client.get_price_for_marketplace(
         &usdc_asset,
-        &Some(100_000000) // $1 minimum
+        &Some(100_000000), // $1 minimum
     );
     assert_eq!(usdc_price.price, 1_00000000);
 
@@ -1063,7 +1088,7 @@ fn test_oracle_consumer_integration_scenario() {
     let mut assets = Vec::new(&e);
     assets.push_back(usdc_asset.clone());
     assets.push_back(eth_asset.clone());
-    
+
     let portfolio_prices = client.get_batch_prices(&assets, &300); // 5 minutes
     assert_eq!(portfolio_prices.len(), 2);
 

--- a/docs/ERROR_EVENTS.md
+++ b/docs/ERROR_EVENTS.md
@@ -33,6 +33,12 @@ Data   : (context : String, message : String, timestamp : u64)
 
 ## Error Code Reference
 
+`price_oracle` exposes contract-specific `OracleError` values for admin and
+publisher authorization failures. In particular, uninitialized admin reads
+return `NotInitialized`, and non-whitelisted price publishers return
+`OracleNotWhitelisted`, so off-chain callers can decode those failures without
+depending on panic strings.
+
 ### Validation (1–99)
 
 | Code | Constant           | Message                                    |

--- a/docs/price_oracle/admin_controls.md
+++ b/docs/price_oracle/admin_controls.md
@@ -27,6 +27,8 @@ Oracle rotation is performed by removing an old oracle address and adding a new 
 
 ## Security Notes
 - Only the admin can modify the whitelist. Attempts by non-admins will fail with `Unauthorized`.
+- Uninitialized admin reads fail with the typed `NotInitialized` error instead of a string panic.
+- Price submissions from non-whitelisted publishers fail with the typed `OracleNotWhitelisted` error instead of a string panic.
 - Whitelisted oracles are trusted to publish honest prices. Compromised oracles can overwrite the latest price for any asset.
 - Downstream contracts should always use `get_price_valid` and set appropriate staleness windows.
 


### PR DESCRIPTION
## Summary
- replace price_oracle admin-read and whitelist panic helpers with typed OracleError propagation
- make set_price return OracleNotWhitelisted for non-whitelisted publishers and get_admin return NotInitialized before setup
- add exact typed-error tests and document the error mapping

Closes #489.

## Validation
- git diff --check
- CARGO_TARGET_DIR=/tmp/commitlabs-oracle-target cargo test -p price_oracle typed_error
- CARGO_TARGET_DIR=/tmp/commitlabs-oracle-target cargo test -p price_oracle

Note: price_oracle still has a pre-existing unused max_deviation_percent warning in get_price_high_value; this PR leaves unrelated behavior unchanged.